### PR TITLE
Separate pubslish workflow and add upload of executable to release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
-name: QA, tests and publishing
+name: QA and tests
 
 on:
     pull_request:
         types: [opened, synchronize, reopened]
     push:
       branches: [main, develop]
-      tags:
-        - '*'
+    workflow_call:
+
 jobs:
   # Checks the style using the pre-commit hooks
   qa:
@@ -84,100 +84,3 @@ jobs:
       # The regression tests (with non coverage)
       - name: Regression tests
         run: pytest tests/test_fullsim_regression.py
-
-  # If all tests pass, we try to build a wheel
-  build-wheel:
-    # needs: [regression-tests, unit-tests]
-    name: Build source distribution
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build sdist
-        run: |
-          python -m pip install --upgrade build
-          python -m build
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: dist/MUSE*
-
-  # And if we are pushing a tag, then we try to publish it
-  publish-TestPyPI:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    needs: build-wheel
-    name: Publish MUSE to TestPyPI
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-
-    steps:
-
-      - name: Download sdist artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-
-      - name: Display structure of downloaded files
-        run: ls -R dist
-
-      - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-
-  publish-PyPI:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    needs: publish-TestPyPI
-    name: Publish MUSE to PyPI
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-
-    steps:
-
-      - name: Download sdist artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-
-      - name: Display structure of downloaded files
-        run: ls -R dist
-
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-  build-standalone:
-    needs: publish-PyPI
-    name: Build standalone executables
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ windows-latest ]
-        python-version: [ "3.9" ]
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pyinstaller
-          python -m pip install -e .[dev,gui]
-
-      - name: Build directory-based standalone
-        run: pyinstaller muse_dir.spec --distpath standalone
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: standalone/MUSE*
-          name: MUSE

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,113 @@
+name: Publishing
+
+on: [release]
+
+jobs:
+  test:
+    uses: ./.github/workflows/ci.yml
+
+  # If tests are successful, we build the wheel and push it to the release
+  build-wheel:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/MUSE*
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: dist/MUSE*
+
+  # If building of the wheel is successful, then we try to publish it
+  # First, in TestPyPI
+  publish-TestPyPI:
+    needs: build-wheel
+    name: Publish MUSE to TestPyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+
+      - name: Download sdist artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - name: Display structure of downloaded files
+        run: ls -R dist
+
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  # And if all goes well, in PyPI
+  publish-PyPI:
+    needs: publish-TestPyPI
+    name: Publish MUSE to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+
+      - name: Download sdist artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - name: Display structure of downloaded files
+        run: ls -R dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  # Finally, if all of these went well, we build the standalone executable
+  # And publish it to the release page, as well
+  build-standalone:
+    needs: publish-PyPI
+    name: Build standalone executables
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest ]
+        python-version: [ "3.9" ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyinstaller
+          python -m pip install -e .[dev,gui]
+
+      - name: Build directory-based standalone
+        run: pyinstaller muse_dir.spec --distpath standalone
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: standalone/MUSE*
+          name: MUSE
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: standalone/MUSE*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Version - Development
 
 ## Features
-
+- Separate publish workflow and add upload of executable to release ([#231](https://github.com/EnergySystemsModellingLab/MUSE_OS/pull/231))
 - Update main branch ([#225](https://github.com/EnergySystemsModellingLab/MUSE_OS/pull/225))
 - Notebooks in the documentation are run as tests ([#178](https://github.com/SGIModel/MUSE_OS/pull/178))
 - Tutorials in the documentation are run as tests ([#177](https://github.com/SGIModel/MUSE_OS/pull/177))


### PR DESCRIPTION
# Description

So far, the tests and publication steps were part of the same workflow, and which part to run were controlled depending on having a tag or not. This PR separates both activities in their own workflow files and enables the test workflow to be trigger from another workflow file, the `publish.yml` file, which is only triggered when there is a release. 

It also adds a couple of steps to this `publish` workflow to upload the wheels and the standalone executable to the release page automatically.

In summary, the steps to publish a new version now are:

1. Merge whatever is required to `main`.
2. Pull the main branch and update the version locally with `bump2version`.
3. Push the commits AND the tags.
4. Create a new release selecting the appropriate version number. Choose `Generate release notes` to automatically get a summary of changes since the last release.
5. This will trigger the new `publish` workflow. After it is completed, if successful, the new version of MUSE will be in PyPI and the standalone version attached to the release.

Fixes # n/a

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/SGIModel/StarMuse/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (whatever its nature)

## Key checklist
n/a 
- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
