### PR TITLE
Edited formatting when reading inputs

### DIFF
--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -87,10 +87,17 @@ def read_technodictionary(filename: Union[Text, Path]) -> xr.Dataset:
     result = xr.Dataset.from_dataframe(data.sort_index())
     if "fuel" in result.variables:
         result["fuel"] = result.fuel.isel(region=0, year=0)
+        result["fuel"].values = [camel_to_snake(name) for name in result["fuel"].values]
     if "type" in result.variables:
         result["tech_type"] = result.type.isel(region=0, year=0)
+        result["tech_type"].values = [
+            camel_to_snake(name) for name in result["tech_type"].values
+        ]
     if "enduse" in result.variables:
         result["enduse"] = result.enduse.isel(region=0, year=0)
+        result["enduse"].values = [
+            camel_to_snake(name) for name in result["enduse"].values
+        ]
 
     units = csv[csv.process_name == "Unit"].drop(
         ["process_name", "region_name", "time", "level"], axis=1
@@ -171,8 +178,10 @@ def read_io_technodata(filename: Union[Text, Path]) -> xr.Dataset:
     data.index = ts
     data.columns.name = "commodity"
     data.index.name = "technology"
-
+    print("====")
+    print(data, "first")
     data = data.rename(columns=camel_to_snake)
+    print(data, "after")
     data = data.apply(partial(pd.to_numeric, errors="ignore"), axis=0)
 
     fixed_set = xr.Dataset.from_dataframe(data[data.level == "fixed"]).drop_vars(


### PR DESCRIPTION
# Description

*Commodity names  in the techndata are not formatted in the same way as in commodities-in, or commodities-out*

Fixes #236 

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/SGIModel/StarMuse/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
