### PR TITLE
Add `pre-commit` hooks to format config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,21 @@
-# EditorConfig is awesome: http://EditorConfig.org
-
-# top-most EditorConfig file
 root = true
 
-[*.py]
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
-tab_width = 4
-charset = utf-8
-max_line_length=88
-insert_final_newline = true
+max_line_length = 88
+
+[*.md]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -14,4 +14,4 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://muse-os.readthedocs.io/en/latest/
-          cmd_params: '--timeout=20 --buffer-size=8192 --max-connections=3 --color=always --skip-tls-verification --header="User-Agent:curl/7.54.0"'  # muffet parameters
+          cmd_params: '--timeout=20 --buffer-size=8192 --max-connections=3 --color=always --skip-tls-verification --header="User-Agent:curl/7.54.0"' # muffet parameters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: QA and tests
 
 on:
-    pull_request:
-        types: [opened, synchronize, reopened]
-    push:
-      branches: [main, develop]
-    workflow_call:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main, develop]
+  workflow_call:
 
 jobs:
   # Checks the style using the pre-commit hooks
@@ -20,7 +20,6 @@ jobs:
     needs: qa
     runs-on: ${{ matrix.os }}
 
-
     strategy:
       fail-fast: false
       matrix:
@@ -28,35 +27,35 @@ jobs:
         python-version: ["3.8", "3.9"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip==22.1.2
-        pip install -U setuptools==62.6.0 wheel xlrd==1.2.0
-        pip install -e .[all]
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip==22.1.2
+          pip install -U setuptools==62.6.0 wheel xlrd==1.2.0
+          pip install -e .[all]
 
-    # The unit tests, with coverage under linux
-    - name: Unit tests (linux)
-      if: (runner.os == 'Linux')
-      run: |
-        pip install pytest-cov
-        pytest -m "not regression and not notebook" --junitxml=junit/pytest.xml \
-            --cov=muse \
-            --cov-branch \
-            --cov-report=xml
+      # The unit tests, with coverage under linux
+      - name: Unit tests (linux)
+        if: (runner.os == 'Linux')
+        run: |
+          pip install pytest-cov
+          pytest -m "not regression and not notebook" --junitxml=junit/pytest.xml \
+              --cov=muse \
+              --cov-branch \
+              --cov-report=xml
 
-    - name: Upload coverage to Codecov
-      if: success() && (runner.os == 'Linux' && matrix.python-version == 3.9)
-      uses: codecov/codecov-action@v4
+      - name: Upload coverage to Codecov
+        if: success() && (runner.os == 'Linux' && matrix.python-version == 3.9)
+        uses: codecov/codecov-action@v4
 
-    - name: Unit tests (not linux)
-      if: (runner.os != 'Linux')
-      run: pytest -m "not regression and not notebook"
+      - name: Unit tests (not linux)
+        if: (runner.os != 'Linux')
+        run: pytest -m "not regression and not notebook"
 
   regression-tests:
     needs: qa

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,49 +1,49 @@
 name: "Build and publish documentation"
 on:
-    pull_request:
-        types: [opened, synchronize, reopened]
-    push:
-        branches: ["main"]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: ["main"]
 
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
-    - name: Install dependencies
-      run: |
-        sudo apt update -y
-        sudo apt install -y pandoc graphviz latexmk texlive-latex-recommended \
-                texlive-latex-extra texlive-fonts-recommended
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools==62.6.0 wheel
-        python -m pip install -e .[doc,dev]
-    - name: Test notebooks and tutorials
-      run: pytest -m "notebook"
-    - name: Build HTML documentation
-      run: python -m sphinx -b html docs docs/build/html
-    - name: Build PDF documentation
-      run: |
-        python -m sphinx -b latex docs docs/build/latex
-        cd docs/build/latex
-        latexmk -interaction=nonstopmode -pdf muse
-    - name: Upload HTML
-      uses: actions/upload-artifact@v4
-      with:
-        name: DocumentationHTML
-        path: docs/build/html
-    - name: Upload PDF
-      uses: actions/upload-artifact@v4
-      with:
-        name: DocumentationPDF
-        path: docs/build/latex/muse.pdf
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v4
-      if: github.ref == 'refs/heads/master'
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/build/html
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y pandoc graphviz latexmk texlive-latex-recommended \
+                  texlive-latex-extra texlive-fonts-recommended
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools==62.6.0 wheel
+          python -m pip install -e .[doc,dev]
+      - name: Test notebooks and tutorials
+        run: pytest -m "notebook"
+      - name: Build HTML documentation
+        run: python -m sphinx -b html docs docs/build/html
+      - name: Build PDF documentation
+        run: |
+          python -m sphinx -b latex docs docs/build/latex
+          cd docs/build/latex
+          latexmk -interaction=nonstopmode -pdf muse
+      - name: Upload HTML
+        uses: actions/upload-artifact@v4
+        with:
+          name: DocumentationHTML
+          path: docs/build/html
+      - name: Upload PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: DocumentationPDF
+          path: docs/build/latex/muse.pdf
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/master'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -2,7 +2,7 @@ name: Pre-commit auto-update
 
 on:
   schedule:
-    - cron: "0 0 * * 1"  # midnight every Monday
+    - cron: "0 0 * * 1" # midnight every Monday
 
 jobs:
   auto-update:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,6 @@ jobs:
       id-token: write
 
     steps:
-
       - name: Download sdist artifact
         uses: actions/download-artifact@v4
         with:
@@ -61,7 +60,6 @@ jobs:
       id-token: write
 
     steps:
-
       - name: Download sdist artifact
         uses: actions/download-artifact@v4
         with:
@@ -84,8 +82,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest ]
-        python-version: [ "3.9" ]
+        os: [windows-latest]
+        python-version: ["3.9"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -3,7 +3,6 @@ on:
     - cron: 0 0 * * 0 # At 12:00 AM, only on Sunday
 
 jobs:
-
   regression-tests:
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/remove_old_artifacts.yml
+++ b/.github/workflows/remove_old_artifacts.yml
@@ -2,7 +2,7 @@ name: Remove old artifacts
 
 on:
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: "0 0 1 * *"
 
 jobs:
   remove-old-artifacts:
@@ -10,9 +10,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - name: Remove old artifacts
-      uses: c-hive/gha-remove-artifacts@v1
-      with:
-        age: '15 days'
-        skip-tags: true
-        skip-recent: 5
+      - name: Remove old artifacts
+        uses: c-hive/gha-remove-artifacts@v1
+        with:
+          age: "15 days"
+          skip-tags: true
+          skip-recent: 5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,8 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, json]
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.13.0
+    hooks:
+      - id: pretty-format-toml
+        args: [--autofix, --indent, "4", --no-sort]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
     hooks:
       - id: nbstripout
         files: ".ipynb"
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.1.0"
+    hooks:
+      - id: prettier
+        types_or: [yaml, json]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:
@@ -24,8 +24,8 @@ sphinx:
 
 # Optionally declare the Python requirements required to build your docs
 python:
-   install:
-   - method: pip
-     path: .
-     extra_requirements:
-         - doc
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,7 +9,8 @@
 		"ms-python.python",
 		"mechatroner.rainbow-csv",
 		"editorconfig.editorconfig",
-		"davidanson.vscode-markdownlint"
+		"davidanson.vscode-markdownlint",
+        "esbenp.prettier-vscode"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,39 +9,28 @@
             "type": "python",
             "request": "launch",
             "module": "muse",
-            "args": [
-                "--model",
-                "default"
-            ]
+            "args": ["--model", "default"]
         },
         {
             "name": "Model: multiple_agents",
             "type": "python",
             "request": "launch",
             "module": "muse",
-            "args": [
-                "--model",
-                "multiple_agents"
-            ]
+            "args": ["--model", "multiple_agents"]
         },
         {
             "name": "model/settings.toml",
             "type": "python",
             "request": "launch",
             "module": "muse",
-            "args": [
-                "model/settings.toml",
-            ]
+            "args": ["model/settings.toml"]
         },
         {
             "name": "Model: minimum_service",
             "type": "python",
             "request": "launch",
             "module": "muse",
-            "args": [
-                "--model",
-                "minimum_service"
-            ]
-        },
+            "args": ["--model", "minimum_service"]
+        }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
     "python.linting.mypyEnabled": true,
     "python.testing.pytestEnabled": true,
     "restructuredtext.confPath": "${workspaceFolder}/docs",
-    "python.pythonPath": "/opt/anaconda3/envs/muse/bin/python",
+    "python.pythonPath": "/opt/anaconda3/envs/muse/bin/python"
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,12 +1,12 @@
 cff-version: 1.1.0
 message: "If you use this software, please cite it as below."
 authors:
-  - family-names: Giarola
-    given-names: Sara
-  - family-names: Kell
-    given-names: Alexander
-  - family-names: Hawkes
-    given-names: Adam
+    - family-names: Giarola
+      given-names: Sara
+    - family-names: Kell
+      given-names: Alexander
+    - family-names: Hawkes
+      given-names: Adam
 
 title: SGIModel/MUSE_OS
 version: v1.0.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,12 +2,12 @@ cff-version: 1.1.0
 message: "If you use this software, please cite it as below."
 authors:
   - family-names: Giarola
-	given-names: Sara
+    given-names: Sara
   - family-names: Kell
-	given-names: Alexander
+    given-names: Alexander
   - family-names: Hawkes
-	given-names: Adam
+    given-names: Adam
 
-title: SGIModel/MUSE_OS: v1.0.1
+title: SGIModel/MUSE_OS
 version: v1.0.1
 date-released: 2022-03-25

--- a/docs/tutorial-code/0-new-decision-metric/settings.toml
+++ b/docs/tutorial-code/0-new-decision-metric/settings.toml
@@ -1,13 +1,12 @@
 plugins = "{path}/new_decision.py"
 # Global settings - most REQUIRED
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -43,12 +42,10 @@ method = "fitting"
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -57,27 +54,24 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -87,17 +81,14 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/power/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -107,23 +98,20 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.gas.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/1-add-new-technology/1-introduction/settings.toml
+++ b/docs/tutorial-code/1-add-new-technology/1-introduction/settings.toml
@@ -1,12 +1,12 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -42,12 +42,10 @@ method = "fitting"
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -56,27 +54,24 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -86,17 +81,14 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/power/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -106,23 +98,20 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.gas.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/1-add-new-technology/2-scenario/settings.toml
+++ b/docs/tutorial-code/1-add-new-technology/2-scenario/settings.toml
@@ -1,12 +1,12 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -41,12 +41,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -55,26 +53,24 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -84,17 +80,14 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/power/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -104,23 +97,20 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.gas.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/2-add-agent/1-multiple-objective/settings.toml
+++ b/docs/tutorial-code/2-add-agent/1-multiple-objective/settings.toml
@@ -1,18 +1,17 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
 tolerance = 0.1
 tolerance_unmet_demand = -0.1
-
 
 [[outputs]]
 quantity = "prices"
@@ -34,7 +33,6 @@ quantity = "timeslice_supply"
 sink = "aggregate"
 filename = "{path}/{default_output_dir}/MCA{Quantity}.csv"
 
-
 # Carbon budget control
 [carbon_budget_control]
 budget = []
@@ -43,12 +41,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -57,26 +53,24 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/residential/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -86,17 +80,14 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/power/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -106,23 +97,20 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.gas.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/2-add-agent/2-single-objective/settings.toml
+++ b/docs/tutorial-code/2-add-agent/2-single-objective/settings.toml
@@ -1,12 +1,12 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -33,7 +33,6 @@ quantity = "timeslice_supply"
 sink = "aggregate"
 filename = "{path}/{default_output_dir}/MCA{Quantity}.csv"
 
-
 # Carbon budget control
 [carbon_budget_control]
 budget = []
@@ -42,12 +41,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -56,27 +53,24 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/residential/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -86,17 +80,14 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/power/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -106,23 +97,20 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.gas.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/3-add-region/settings.toml
+++ b/docs/tutorial-code/3-add-region/settings.toml
@@ -1,12 +1,12 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1", "R2"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -41,12 +41,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -55,27 +53,24 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/residential/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -85,17 +80,14 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/power/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -105,23 +97,20 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.gas.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/4-modify-timing-data/1-modify-timeslices/settings.toml
+++ b/docs/tutorial-code/4-modify-timing-data/1-modify-timeslices/settings.toml
@@ -1,12 +1,12 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1", "R2"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -33,7 +33,6 @@ quantity = "timeslice_supply"
 sink = "aggregate"
 filename = "{path}/{default_output_dir}/MCA{Quantity}.csv"
 
-
 # Carbon budget control
 [carbon_budget_control]
 budget = []
@@ -42,12 +41,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -56,27 +53,24 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/residential/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -86,17 +80,14 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/power/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -106,19 +97,17 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.gas.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1095
 all-year.all-week.morning = 1095
 all-year.all-week.mid-afternoon = 1095
@@ -127,4 +116,3 @@ all-year.all-week.late-peak = 1095
 all-year.all-week.evening = 1095
 all-year.all-week.early-morning = 1095
 all-year.all-week.late-afternoon = 1095
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/4-modify-timing-data/2-modify-time-framework/settings.toml
+++ b/docs/tutorial-code/4-modify-timing-data/2-modify-time-framework/settings.toml
@@ -1,12 +1,12 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2022, 2024, 2026, 2028, 2030, 2032, 2034, 2036, 2038, 2040]
-foresight = 2   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 2  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1", "R2"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -41,12 +41,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -55,26 +53,24 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/residential/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 2  # Optional, defaults to 5
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -85,17 +81,14 @@ existing_capacity = '{path}/technodata/power/ExistingCapacity.csv'
 lpsolver = "scipy"
 forecast = 2  # Optional, defaults to 5
 
-
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -106,20 +99,18 @@ existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
 forecast = 2  # Optional, defaults to 5
 
-
 [[sectors.gas.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
 forecast = 2  # Optional, defaults to 5
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1095
 all-year.all-week.morning = 1095
 all-year.all-week.mid-afternoon = 1095
@@ -128,4 +119,3 @@ all-year.all-week.late-peak = 1095
 all-year.all-week.evening = 1095
 all-year.all-week.early-morning = 1095
 all-year.all-week.late-afternoon = 1095
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/5-add-service-demand/settings.toml
+++ b/docs/tutorial-code/5-add-service-demand/settings.toml
@@ -1,12 +1,12 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1", "R2"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -23,7 +23,6 @@ quantity = "capacity"
 sink = "aggregate"
 filename = "{path}/{default_output_dir}/MCA{Quantity}.csv"
 
-
 [[outputs]]
 quantity = "timeslice_consumption"
 sink = "aggregate"
@@ -34,7 +33,6 @@ quantity = "timeslice_supply"
 sink = "aggregate"
 filename = "{path}/{default_output_dir}/MCA{Quantity}.csv"
 
-
 # Carbon budget control
 [carbon_budget_control]
 budget = []
@@ -43,12 +41,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -57,26 +53,24 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/residential/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -86,17 +80,14 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/power/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -106,19 +97,17 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.gas.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1095
 all-year.all-week.morning = 1095
 all-year.all-week.mid-afternoon = 1095
@@ -127,4 +116,3 @@ all-year.all-week.late-peak = 1095
 all-year.all-week.evening = 1095
 all-year.all-week.early-morning = 1095
 all-year.all-week.late-afternoon = 1095
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/6-add-correlation-demand/settings.toml
+++ b/docs/tutorial-code/6-add-correlation-demand/settings.toml
@@ -1,18 +1,17 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
 tolerance = 0.1
 tolerance_unmet_demand = -0.1
-
 
 [[outputs]]
 quantity = "prices"
@@ -23,7 +22,6 @@ filename = "{path}/{default_output_dir}/MCA{Quantity}.csv"
 quantity = "capacity"
 sink = "aggregate"
 filename = "{path}/{default_output_dir}/MCA{Quantity}.csv"
-
 
 [[outputs]]
 quantity = "timeslice_consumption"
@@ -44,12 +42,10 @@ method = "fitting"
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -58,26 +54,24 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -87,17 +81,14 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/power/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
 
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -107,12 +98,9 @@ agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
 
-
 [[sectors.gas.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
-
-
 
 [sectors.residential_presets]
 type = 'presets'
@@ -122,11 +110,10 @@ timeslice_shares_path = '{path}/TimesliceSharepreset.csv'
 macrodrivers_path = '{path}/Macrodrivers.csv'
 regression_path = '{path}/regressionparameters.csv'
 forecast = 0
-filters = {sector="residential", region=["R1"]}
-
-
+filters = {sector = "residential", region = ["R1"]}
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1095
 all-year.all-week.morning = 1095
 all-year.all-week.mid-afternoon = 1095
@@ -135,4 +122,3 @@ all-year.all-week.late-peak = 1095
 all-year.all-week.evening = 1095
 all-year.all-week.early-morning = 1095
 all-year.all-week.late-afternoon = 1095
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/7-min-max-timeslice-constraints/1-min-constraint/settings.toml
+++ b/docs/tutorial-code/7-min-max-timeslice-constraints/1-min-constraint/settings.toml
@@ -1,20 +1,17 @@
 plugins = "{path}/output.py"
-
 # Global settings - most REQUIRED
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
-excluded_commodities=["solar", "wind"]
-
+excluded_commodities = ["solar", "wind"]
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
 tolerance = 0.1
 tolerance_unmet_demand = -0.1
-
 
 [[outputs]]
 quantity = "prices"
@@ -26,7 +23,6 @@ quantity = "capacity"
 sink = "aggregate"
 filename = "{path}/{default_output_dir}/MCA{Quantity}.csv"
 
-
 # Carbon budget control
 [carbon_budget_control]
 budget = []
@@ -35,12 +31,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -49,11 +43,12 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
@@ -67,23 +62,20 @@ index = false
 
 [[sectors.residential.outputs]]
 filename = '{path}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
+sink = 'csv'
+overwrite = true
 quantity.name = "supply"
 quantity.sum_over = "timeslice"
 quantity.drop = ["comm_usage", "units_prices"]
-sink = 'csv'
-overwrite = true
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'costed'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 technodata_timeslices = '{path}/technodata/power/TechnodataTimeslices.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
@@ -106,47 +98,49 @@ filename = '{path}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
 quantity = "supply_timeslice"
 sink = "csv"
 overwrite = true
-index=false
-keep_columns = [ "timeslice",
-                 "asset",
-                 "year",
-                 "commodity",
-                 "region",
-                 "installed",
-                 "technology",
-                 "month",
-                 "day",
-                 "hour",
-                 "supply"]
+index = false
+keep_columns = [
+    "timeslice",
+    "asset",
+    "year",
+    "commodity",
+    "region",
+    "installed",
+    "technology",
+    "month",
+    "day",
+    "hour",
+    "supply"
+]
 
 [[sectors.power.outputs]]
 filename = '{path}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
 quantity = "consumption_timeslice"
 sink = "csv"
 overwrite = true
-index=false
-keep_columns = [ "timeslice",
-                 "asset",
-                 "year",
-                 "commodity",
-                 "region",
-                 "installed",
-                 "technology",
-                 "month",
-                 "day",
-                 "hour",
-                 "consumption"]
+index = false
+keep_columns = [
+    "timeslice",
+    "asset",
+    "year",
+    "commodity",
+    "region",
+    "installed",
+    "technology",
+    "month",
+    "day",
+    "hour",
+    "consumption"
+]
 
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -155,7 +149,6 @@ commodities_out = '{path}/technodata/gas/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
-
 
 [[sectors.gas.outputs]]
 filename = '{path}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
@@ -168,18 +161,16 @@ index = false
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]

--- a/docs/tutorial-code/7-min-max-timeslice-constraints/2-max-constraint/settings.toml
+++ b/docs/tutorial-code/7-min-max-timeslice-constraints/2-max-constraint/settings.toml
@@ -1,14 +1,12 @@
 plugins = "{path}/output.py"
-
 # Global settings - most REQUIRED
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5   # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
-excluded_commodities=["solar", "wind"]
-
+excluded_commodities = ["solar", "wind"]
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -34,12 +32,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -48,11 +44,12 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
 lpsolver = "scipy"  # Optional, defaults to "adhoc"
-constraints = [  # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"  # Optional, default to new_and_retro
 forecast = 5  # Optional, defaults to 5
@@ -66,23 +63,20 @@ index = false
 
 [[sectors.residential.outputs]]
 filename = '{path}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
+sink = 'csv'
+overwrite = true
 quantity.name = "supply"
 quantity.sum_over = "timeslice"
 quantity.drop = ["comm_usage", "units_prices"]
-sink = 'csv'
-overwrite = true
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'costed'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 technodata_timeslices = '{path}/technodata/power/TechnodataTimeslices.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
@@ -105,48 +99,49 @@ filename = '{path}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
 quantity = "supply_timeslice"
 sink = "csv"
 overwrite = true
-index=false
-keep_columns = [ "timeslice",
-                 "asset",
-                 "year",
-                 "commodity",
-                 "region",
-                 "installed",
-                 "technology",
-                 "month",
-                 "day",
-                 "hour",
-                 "supply"]
-
+index = false
+keep_columns = [
+    "timeslice",
+    "asset",
+    "year",
+    "commodity",
+    "region",
+    "installed",
+    "technology",
+    "month",
+    "day",
+    "hour",
+    "supply"
+]
 
 [[sectors.power.outputs]]
 filename = '{path}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
 quantity = "consumption_timeslice"
 sink = "csv"
 overwrite = true
-index=false
-keep_columns = [ "timeslice",
-                 "asset",
-                 "year",
-                 "commodity",
-                 "region",
-                 "installed",
-                 "technology",
-                 "month",
-                 "day",
-                 "hour",
-                 "consumption"]
+index = false
+keep_columns = [
+    "timeslice",
+    "asset",
+    "year",
+    "commodity",
+    "region",
+    "installed",
+    "technology",
+    "month",
+    "day",
+    "hour",
+    "consumption"
+]
 
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -155,7 +150,6 @@ commodities_out = '{path}/technodata/gas/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
-
 
 [[sectors.gas.outputs]]
 filename = '{path}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
@@ -168,18 +162,16 @@ index = false
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
-consumption_path= "{path}/technodata/preset/*Consumption.csv"
-
+consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MUSE_OS"
 authors = [
-    {name = "Sustainable Gas Institute", email = "sgi@imperial.ac.uk"},
+    {name = "Sustainable Gas Institute", email = "sgi@imperial.ac.uk"}
 ]
 description = "Energy System Model"
 readme = "README.md"
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Other Audience",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
 dependencies = [
     "numpy==1.23.0",
@@ -30,7 +30,7 @@ dependencies = [
     "toml",
     "xlrd==1.2.0",
     "mypy-extensions",
-    "pypubsub",
+    "pypubsub"
 ]
 dynamic = ["version"]
 
@@ -63,7 +63,7 @@ doc = [
 ]
 excel = ["openpyxl"]
 gui = [
-    "gooey",
+    "gooey"
 ]
 
 [project.urls]
@@ -97,7 +97,7 @@ markers = [
     "sgidata: test that require legacy data",
     "legacy: test that require legacy modules",
     "regression: a regression test",
-    "notebook: a test which consist in running a jupyter notebook",
+    "notebook: a test which consist in running a jupyter notebook"
 ]
 
 [tool.mypy]

--- a/src/muse/data/default_settings.toml
+++ b/src/muse/data/default_settings.toml
@@ -1,4 +1,5 @@
 # Global settings
+
 time_framework = 'REQUIRED'
 # foresight must  be a multiple of the minimum separation between the years in time
 # framework
@@ -7,7 +8,6 @@ regions = 'REQUIRED'
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
-
 # Convergence parameters
 equilibrium = true
 equilibrium_variable = 'demand'
@@ -18,7 +18,7 @@ excluded_commodities = []
 
 # Carbon budget control
 [carbon_budget_control]
-budget = []          # Same length as time_framework
+budget = []  # Same length as time_framework
 commodities = []
 method = 'fitting'
 debug = true
@@ -49,6 +49,7 @@ base_year_export = "OPTIONAL"
 base_year_import = "OPTIONAL"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 winter.weekday.night = 396
 winter.weekday.morning = 396
 winter.weekday.afternoon = 264
@@ -70,7 +71,7 @@ spring-autumn.weekend.morning = 300
 spring-autumn.weekend.afternoon = 300
 spring-autumn.weekend.evening = 300
 summer.weekday.night = 396
-summer.weekday.morning  = 396
+summer.weekday.morning = 396
 summer.weekday.afternoon = 264
 summer.weekday.early-peak = 66
 summer.weekday.late-peak = 66
@@ -79,8 +80,6 @@ summer.weekend.night = 150
 summer.weekend.morning = 150
 summer.weekend.afternoon = 150
 summer.weekend.evening = 150
-level_names = ["month", "day", "hour"]
-
 
 [timeslices.aggregates]
 all-day = ["night", "morning", "afternoon", "early-peak", "late-peak", "evening"]

--- a/src/muse/data/example/default/settings.toml
+++ b/src/muse/data/example/default/settings.toml
@@ -1,12 +1,12 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5                                               # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 1
@@ -31,7 +31,7 @@ keep_columns = [
     'sector',
     'type',
     'year',
-    'capacity',
+    'capacity'
 ]
 
 # Carbon budget control
@@ -42,12 +42,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -55,15 +53,16 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 [sectors.residential.subsectors.retro_and_new]
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
-lpsolver = "scipy" # Optional, defaults to "adhoc"
-constraints = [ # Optional, defaults to the constraints below
+lpsolver = "scipy"  # Optional, defaults to "adhoc"
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
-demand_share = "new_and_retro" # Optional, default to new_and_retro
-forecast = 5 # Optional, defaults to 5
+demand_share = "new_and_retro"  # Optional, default to new_and_retro
+forecast = 5  # Optional, defaults to 5
 
 [[sectors.residential.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
@@ -74,23 +73,20 @@ index = false
 
 [[sectors.residential.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
+sink = 'csv'
+overwrite = true
 quantity.name = "supply"
 quantity.sum_over = "timeslice"
 quantity.drop = ["comm_usage", "units_prices"]
-sink = 'csv'
-overwrite = true
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
 commodities_out = '{path}/technodata/power/CommOut.csv'
@@ -111,12 +107,10 @@ index = false
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -125,7 +119,6 @@ commodities_out = '{path}/technodata/gas/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
-
 
 [[sectors.gas.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
@@ -138,18 +131,16 @@ index = false
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
 consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
-
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]

--- a/src/muse/data/example/default_timeslice/settings.toml
+++ b/src/muse/data/example/default_timeslice/settings.toml
@@ -1,12 +1,12 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
-foresight = 5                                               # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -44,12 +44,10 @@ budget = []
 projections = '{path}/input/Projections.csv'
 global_commodities = '{path}/input/GlobalCommodities.csv'
 
-
 [sectors.residential]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/residential/Technodata.csv'
 commodities_in = '{path}/technodata/residential/CommIn.csv'
 commodities_out = '{path}/technodata/residential/CommOut.csv'
@@ -57,15 +55,16 @@ commodities_out = '{path}/technodata/residential/CommOut.csv'
 [sectors.residential.subsectors.retro_and_new]
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/residential/ExistingCapacity.csv'
-lpsolver = "scipy" # Optional, defaults to "adhoc"
-constraints = [ # Optional, defaults to the constraints below
+lpsolver = "scipy"  # Optional, defaults to "adhoc"
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
-demand_share = "new_and_retro" # Optional, default to new_and_retro
-forecast = 5 # Optional, defaults to 5
+demand_share = "new_and_retro"  # Optional, default to new_and_retro
+forecast = 5  # Optional, defaults to 5
 
 [[sectors.residential.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
@@ -76,23 +75,20 @@ index = false
 
 [[sectors.residential.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
+sink = 'csv'
+overwrite = true
 quantity.name = "supply"
 quantity.sum_over = "timeslice"
 quantity.drop = ["comm_usage", "units_prices"]
-sink = 'csv'
-overwrite = true
-
 
 [[sectors.residential.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.power]
 type = 'default'
 priority = 2
 dispatch_production = 'costed'
-
 technodata = '{path}/technodata/power/Technodata.csv'
 technodata_timeslices = '{path}/technodata/power/TechnodataTimeslices.csv'
 commodities_in = '{path}/technodata/power/CommIn.csv'
@@ -112,22 +108,19 @@ index = false
 
 [[sectors.power.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
-quantity.name = "supply"
-quantity.drop = ["comm_usage", "units_prices"]
 sink = 'csv'
 overwrite = true
-
+quantity.name = "supply"
+quantity.drop = ["comm_usage", "units_prices"]
 
 [[sectors.power.interactions]]
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.gas]
 type = 'default'
 priority = 3
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/gas/Technodata.csv'
 commodities_in = '{path}/technodata/gas/CommIn.csv'
 commodities_out = '{path}/technodata/gas/CommOut.csv'
@@ -136,7 +129,6 @@ commodities_out = '{path}/technodata/gas/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/gas/ExistingCapacity.csv'
 lpsolver = "scipy"
-
 
 [[sectors.gas.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
@@ -149,18 +141,16 @@ index = false
 net = 'new_to_retro'
 interaction = 'transfer'
 
-
 [sectors.residential_presets]
 type = 'presets'
 priority = 0
 consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
-
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]

--- a/src/muse/data/example/minimum_service/settings.toml
+++ b/src/muse/data/example/minimum_service/settings.toml
@@ -1,4 +1,5 @@
 # Global settings - most REQUIRED
+
 time_framework = [2010, 2015, 2020, 2025, 2030, 2035, 2040, 2045, 2050]
 # Has to be a multiple of the minimum separation between the years in time framework
 foresight = 5
@@ -7,7 +8,6 @@ interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["fuel1", "fuel2", "fuel3"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 2
@@ -39,14 +39,13 @@ keep_columns = [
     'sector',
     'type',
     'year',
-    'capacity',
+    'capacity'
 ]
 
 [sectors.industry]
 type = 'default'
 priority = 1
 dispatch_production = 'share'
-
 technodata = '{path}/technodata/industry/Technodata.csv'
 commodities_in = '{path}/technodata/industry/CommIn.csv'
 commodities_out = '{path}/technodata/industry/CommOut.csv'
@@ -55,15 +54,16 @@ commodities_out = '{path}/technodata/industry/CommOut.csv'
 agents = '{path}/technodata/Agents.csv'
 existing_capacity = '{path}/technodata/industry/Existing.csv'
 lpsolver = "scipy"
-constraints = [ # Optional, defaults to the constraints below
+constraints = [
+    # Optional, defaults to the constraints below
     "max_production",
     "max_capacity_expansion",
     "demand",
     "search_space",
-    "minimum_service",
+    "minimum_service"
 ]
-demand_share = "new_and_retro" # Optional, default to new_and_retro
-forecast = 5 # Optional, defaults to 5
+demand_share = "new_and_retro"  # Optional, default to new_and_retro
+forecast = 5  # Optional, defaults to 5
 
 [[sectors.industry.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
@@ -74,11 +74,11 @@ index = false
 
 [[sectors.industry.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
+sink = 'csv'
+overwrite = true
 quantity.name = "supply"
 quantity.sum_over = "timeslice"
 quantity.drop = ["comm_usage", "units_prices"]
-sink = 'csv'
-overwrite = true
 
 [[sectors.industry.interactions]]
 net = 'new_to_retro'
@@ -90,7 +90,7 @@ priority = 0
 consumption_path = "{path}/technodata/preset/*Consumption.csv"
 
 [timeslices]
+level_names = ["month", "day", "hour"]
 winter.all-week.all-day = 2920
 summer.all-week.all-day = 2920
 spring-autumn.all-week.all-day = 2920
-level_names = ["month", "day", "hour"]

--- a/src/muse/data/example/trade/settings.toml
+++ b/src/muse/data/example/trade/settings.toml
@@ -1,12 +1,12 @@
 # Global settings - most REQUIRED
+
 time_framework = [2020, 2025, 2030, 2035]
-foresight = 5                             # Has to be a multiple of the minimum separation between the years in time framework
+foresight = 5  # Has to be a multiple of the minimum separation between the years in time framework
 regions = ["R1", "R2"]
 interest_rate = 0.1
 interpolation_mode = 'Active'
 log_level = 'info'
 excluded_commodities = ["wind"]
-
 # Convergence parameters
 equilibrium_variable = 'demand'
 maximum_iterations = 100
@@ -15,19 +15,20 @@ tolerance_unmet_demand = -0.1
 
 [[outputs]]
 quantity = "prices"
+filename = "{cwd}/Results/Prices.csv"
 sink.name = "aggregate"
 sink.sink.name = "csv"
 sink.sink.set_index = ["region", "commodity", "year", "timeslice"]
 sink.sink.sort_index = true
 sink.sink.keep_columns = ["prices"]
-filename = "{cwd}/Results/Prices.csv"
 
 [[outputs]]
 quantity = "capacity"
+index = false
+filename = "{cwd}/Results/Capacities.csv"
 sink.name = "aggregate"
 sink.sink.name = "csv"
 sink.sink.sort_index = true
-index = false
 sink.sink.keep_columns = [
     'technology',
     'dst_region',
@@ -36,9 +37,8 @@ sink.sink.keep_columns = [
     'sector',
     'type',
     'year',
-    'capacity',
+    'capacity'
 ]
-filename = "{cwd}/Results/Capacities.csv"
 
 [carbon_budget_control]
 budget = []
@@ -71,12 +71,11 @@ constraints = [
     "max_capacity_expansion",
     "minimum_service",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "new_and_retro"
 forecast = 5
 asset_threshhold = 1e-4
-
 
 [[sectors.residential.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
@@ -109,7 +108,7 @@ constraints = [
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "unmet_forecasted_demand"
 forecast = 5
@@ -127,7 +126,7 @@ columns = [
     "region",
     "technology",
     "installed",
-    "capacity",
+    "capacity"
 ]
 index = false
 
@@ -150,7 +149,7 @@ constraints = [
     "max_production",
     "max_capacity_expansion",
     "demand",
-    "search_space",
+    "search_space"
 ]
 demand_share = "unmet_forecasted_demand"
 forecast = 5
@@ -168,16 +167,15 @@ columns = [
     "region",
     "technology",
     "installed",
-    "capacity",
+    "capacity"
 ]
 index = false
 
-
 [timeslices]
+level_names = ["month", "day", "hour"]
 all-year.all-week.night = 1460
 all-year.all-week.morning = 1460
 all-year.all-week.afternoon = 1460
 all-year.all-week.early-peak = 1460
 all-year.all-week.late-peak = 1460
 all-year.all-week.evening = 1460
-level_names = ["month", "day", "hour"]


### PR DESCRIPTION
Apologies about all the whitespace-related PRs!

I thought while I was at it, it might be useful to have consistent formatting for our config files too (in particular, there are a lot of TOML files in this repo). I've added the `prettier` hook that we've used elsewhere for JSON and YAML files and another one for TOML (which is sadly not supported by `prettier`).

One upside of doing this is that it will also detect syntax errors in these files.

This is the last thing I wanted to do before adding that `ruff` hook.