### PR TITLE
Fix for models with no existing capacity (v2)

### DIFF
--- a/src/muse/demand_share.py
+++ b/src/muse/demand_share.py
@@ -469,13 +469,8 @@ def _inner_split(
     for key, capacity in assets.items():
         method_result = method(capacity=capacity)
         if method_result.asset.size > 0:
-            shares[key] = (
-                method_result.groupby("technology")
-                .sum("asset")
-                .rename(technology="asset")
-            )
-        else:
-            shares[key] = (method_result).rename(technology="asset")
+            method_result = method_result.groupby("technology").sum("asset")
+        shares[key] = method_result.rename(technology="asset")
 
     try:
         total = sum(shares.values()).sum("asset")  # type: ignore

--- a/src/muse/outputs/sinks.py
+++ b/src/muse/outputs/sinks.py
@@ -320,23 +320,25 @@ class YearlyAggregate:
         self.axis = axis
 
     def __call__(self, data: Union[pd.DataFrame, xr.DataArray], year: int):
-        if data is not None:
-            if isinstance(data, xr.DataArray):
-                dataframe = data.to_dataframe()
-            else:
-                dataframe = data
-            if self.axis in dataframe.columns:
-                dataframe = dataframe[dataframe[self.axis] == year]
-            elif self.axis in getattr(dataframe.index, "names", []):
-                dataframe = dataframe.xs(year, level=self.axis).assign(year=year)
-            if self.aggregate is None:
-                self.aggregate = dataframe
-            else:
-                self.aggregate = pd.concat((self.aggregate, dataframe), sort=True)
-            assert self.aggregate is not None
-            if getattr(data, "name", None) is not None:
-                self.aggregate.name = data.name
-            return self.sink(self.aggregate, year=year)
+        if data is None:
+            return None
+
+        if isinstance(data, xr.DataArray):
+            dataframe = data.to_dataframe()
+        else:
+            dataframe = data
+        if self.axis in dataframe.columns:
+            dataframe = dataframe[dataframe[self.axis] == year]
+        elif self.axis in getattr(dataframe.index, "names", []):
+            dataframe = dataframe.xs(year, level=self.axis).assign(year=year)
+        if self.aggregate is None:
+            self.aggregate = dataframe
+        else:
+            self.aggregate = pd.concat((self.aggregate, dataframe), sort=True)
+        assert self.aggregate is not None
+        if getattr(data, "name", None) is not None:
+            self.aggregate.name = data.name
+        return self.sink(self.aggregate, year=year)
 
 
 class FiniteResourceException(Exception):

--- a/src/muse/outputs/sinks.py
+++ b/src/muse/outputs/sinks.py
@@ -320,22 +320,23 @@ class YearlyAggregate:
         self.axis = axis
 
     def __call__(self, data: Union[pd.DataFrame, xr.DataArray], year: int):
-        if isinstance(data, xr.DataArray):
-            dataframe = data.to_dataframe()
-        else:
-            dataframe = data
-        if self.axis in dataframe.columns:
-            dataframe = dataframe[dataframe[self.axis] == year]
-        elif self.axis in getattr(dataframe.index, "names", []):
-            dataframe = dataframe.xs(year, level=self.axis).assign(year=year)
-        if self.aggregate is None:
-            self.aggregate = dataframe
-        else:
-            self.aggregate = pd.concat((self.aggregate, dataframe), sort=True)
-        assert self.aggregate is not None
-        if getattr(data, "name", None) is not None:
-            self.aggregate.name = data.name
-        return self.sink(self.aggregate, year=year)
+        if data is not None:
+            if isinstance(data, xr.DataArray):
+                dataframe = data.to_dataframe()
+            else:
+                dataframe = data
+            if self.axis in dataframe.columns:
+                dataframe = dataframe[dataframe[self.axis] == year]
+            elif self.axis in getattr(dataframe.index, "names", []):
+                dataframe = dataframe.xs(year, level=self.axis).assign(year=year)
+            if self.aggregate is None:
+                self.aggregate = dataframe
+            else:
+                self.aggregate = pd.concat((self.aggregate, dataframe), sort=True)
+            assert self.aggregate is not None
+            if getattr(data, "name", None) is not None:
+                self.aggregate.name = data.name
+            return self.sink(self.aggregate, year=year)
 
 
 class FiniteResourceException(Exception):

--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -217,12 +217,6 @@ class Subsector:
                 [agent.assets for agent in agents], technologies
             )
 
-        # len(commodities) == 0 may happen only if
-        # we run only one region or all regions have no outputs
-        msg = f"Subsector with {techs.technology.values[0]} has no output commodities"
-        if len(commodities) == 0:
-            raise RuntimeError(msg)
-
         demand_share = ds.factory(undo_damage(getattr(settings, "demand_share", None)))
         constraints = cs.factory(getattr(settings, "constraints", None))
         # only used by non-self-investing agents


### PR DESCRIPTION
# Description

Models were previously raising a `RuntimeError` if the existing capacity for a technology was zero for all years (based on a check in the `factory` method of the `Subsector` class). I have removed this check, and modified subsequent steps so it can handle this case.

Fixes #286 

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/SGIModel/StarMuse/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
