### PR TITLE
.vscode/launch.json: Change types to debugpy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,28 +6,28 @@
     "configurations": [
         {
             "name": "Model: default",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "muse",
             "args": ["--model", "default"]
         },
         {
             "name": "Model: multiple_agents",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "muse",
             "args": ["--model", "multiple_agents"]
         },
         {
             "name": "model/settings.toml",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "muse",
             "args": ["model/settings.toml"]
         },
         {
             "name": "Model: minimum_service",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "muse",
             "args": ["--model", "minimum_service"]


### PR DESCRIPTION
It seems that using a type of `python` is deprecated and we should all be using `debugpy` instead. I'm not sure if VS Code's error message means that the debugging configs are currently being run with the old Python extension, but either way we should fix it.
