### PR TITLE
Enable ruff's pydocstyle checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,12 @@ ignore_errors = true
 
 [tool.ruff.lint]
 select = [
+    "D",  # pydocstyle
     "E",  # pycodestyle
     "F",  # Pyflakes
     "I"  # isort
 ]
-ignore = []
+ignore = [
+    "D1"  # missing docstring checks
+]
+pydocstyle.convention = "google"

--- a/src/muse/__init__.py
+++ b/src/muse/__init__.py
@@ -1,4 +1,4 @@
-"""MUSE model"""
+"""MUSE model."""
 
 import os
 

--- a/src/muse/agents/agent.py
+++ b/src/muse/agents/agent.py
@@ -32,17 +32,18 @@ class AbstractAgent(ABC):
                 instance. The information should not be anything describing the
                 technologies themselves, but rather the stock of assets held by
                 the agent.
-            category: optional attribute that could be used to classify
-                different agents together.
-            quantity: different agents' share of the population
+            category: optional value that could be used to classify different agents
+                together.
+            quantity: optional value to classify different agents' share of the
+                population.
         """
         from uuid import uuid4
 
         super().__init__()
         self.name = name
-        """ Name associated with the agent """
+        """Name associated with the agent."""
         self.region = region
-        """ Region the agent operates in """
+        """Region the agent operates in."""
         self.assets = assets if assets is not None else xr.Dataset()
         """Current stock of technologies."""
         self.uuid = uuid4()

--- a/src/muse/agents/agent.py
+++ b/src/muse/agents/agent.py
@@ -34,6 +34,7 @@ class AbstractAgent(ABC):
                 the agent.
             category: optional attribute that could be used to classify
                 different agents together.
+            quantity: different agents' share of the population
         """
         from uuid import uuid4
 
@@ -51,7 +52,7 @@ class AbstractAgent(ABC):
         self.category = category
         """Attribute to classify different sets of agents."""
         self.quantity = quantity
-        """Attribute to classify different agents share of the population"""
+        """Attribute to classify different agents' share of the population."""
 
     def filter_input(
         self,
@@ -116,19 +117,23 @@ class Agent(AbstractAgent):
         category: Optional[Text] = None,
         asset_threshhold: float = 1e-4,
         quantity: Optional[float] = 1,
+        spend_limit: int = 0,
         **kwargs,
     ):
         """Creates a standard buildings agent.
 
         Arguments:
-            assets: Current stock of technologies.
             name: Name of the agent, used for cross-refencing external tables
             region: Region where the agent operates, used for cross-referencing
                 external tables.
+            assets: Current stock of technologies.
+            interpolation: interpolation method. see `xarray.interp`.
             search_rules: method used to filter the search space
+            objectives: One or more objectives by which to decide next investments.
+            decision: single decision objective from one or more objectives.
+            year: year the agent is created / current year
             maturity_threshhold: threshold when filtering replacement
                 technologies with respect to market share
-            year: year the agent is created / current year
             forecast: Number of years the agent will forecast
             housekeeping: transform applied to the assets at the start of
                 iteration. Defaults to doing nothing.
@@ -137,6 +142,10 @@ class Agent(AbstractAgent):
             demand_threshhold: criteria below which the demand is zero.
             category: optional attribute that could be used to classify
                 different agents together.
+            asset_threshhold: Threshold below which assets are not added.
+            quantity: different agents' share of the population
+            spend_limit: The cost above which agents will not invest
+            **kwargs: Extra arguments
         """
         from muse.decisions import factory as decision_factory
         from muse.filters import factory as filter_factory
@@ -175,8 +184,7 @@ class Agent(AbstractAgent):
         Threshold when and if filtering replacement technologies with respect
         to market share.
         """
-        if kwargs is not None:
-            self.spend_limit = kwargs.get("spend_limit", 0)
+        self.spend_limit = spend_limit
 
         if objectives is None:
             objectives = objectives_factory()
@@ -366,8 +374,9 @@ class InvestingAgent(Agent):
 
         Arguments:
             *args: See :py:class:`~muse.agents.agent.Agent`
-            *kwargs: See :py:class:`~muse.agents.agent.Agent`
+            constraints: Set of constraints limiting investment
             investment: A function to perform investments
+            **kwargs: See :py:class:`~muse.agents.agent.Agent`
         """
         from muse.constraints import factory as csfactory
         from muse.investments import factory as ifactory

--- a/src/muse/carbon_budget.py
+++ b/src/muse/carbon_budget.py
@@ -44,7 +44,9 @@ def update_carbon_budget(
     under: bool = True,
 ) -> float:
     """Adjust the carbon budget in the far future if emissions too high or low.
+
     This feature can allow to simulate overshoot shifting.
+
     Arguments:
         carbon_budget: budget for future year,
         emissions: emission for future year,
@@ -80,18 +82,17 @@ def fitting(
     price_too_high_threshold: float = 10,
     fitter: Text = "slinear",
 ) -> float:
-    """
-    Used to solve the carbon market: given the
-    emission of a period, adjusts carbon price to meet the budget.
-    A carbon market is meant as a pool of emissions for all
-    the modelled regions; therefore, the carbon price applies
-    to all modelled regions.
-    The method solves an equation applying
-    a fitting of the emission-carbon price relation
+    """Used to solve the carbon market.
+
+    Given the emission of a period, adjusts carbon price to meet the budget. A carbon
+    market is meant as a pool of emissions for all the modelled regions; therefore, the
+    carbon price applies to all modelled regions. The method solves an equation applying
+    a fitting of the emission-carbon price relation.
+
     Arguments:
         market: Market, with the prices, supply, and consumption,
         sectors: list of market sectors,
-        equilibrium: Method for searching maerket equilibrium,
+        equilibrium: Method for searching market equilibrium,
         carbon_budget: limit on emissions,
         carbon_price: current carbon price
         commodities: list of commodities to limit (ie. emissions),
@@ -103,7 +104,6 @@ def fitting(
     Returns:
         new_price: adjusted carbon price to meet budget
     """
-
     future = market.year[-1]
 
     threshold = carbon_budget.sel(year=future).values
@@ -160,8 +160,10 @@ def refine_new_price(
     commodities: list,
     price_too_high_threshold: float,
 ) -> float:
-    """Refine the value of the carbon price to ensure it is not too high or low
-    compared to heuristics values
+    """Refine the value of the carbon price.
+
+    Ensure it is not too high or low compared to heuristic values.
+
     Arguments:
         market: Market, with prices, supply, and consumption,
         historic_price: DataArray with the historic carbon prices,
@@ -172,7 +174,7 @@ def refine_new_price(
         price_too_high_threshold: Threshold to decide what is a price too high.
 
     Returns:
-        A refined carbon price.
+        The new carbon price
     """
     future = market.year[-1]
 
@@ -210,8 +212,7 @@ def exponential_fun(x, a, b, c):
 
 
 def create_sample(carbon_price, current_emissions, budget, size=4):
-    """Calculates a sample of carbon prices to estimate the adjusted carbon
-    price.
+    """Calculates a sample of carbon prices to estimate the adjusted carbon price.
 
     For each of these prices, the equilibrium loop will be run, obtaining a new value
     for the emissions. Out of those price-emissions pairs, the final carbon price will
@@ -262,8 +263,8 @@ def linear(prices: np.ndarray, emissions: np.ndarray, budget: int) -> float:
 def linear_guess_and_weights(
     prices: np.ndarray, emissions: np.ndarray, budget: int
 ) -> tuple:
-    """Estimates initial values for the linear fitting algorithm and the
-    weights.
+    """Estimates initial values for the linear fitting algorithm and the weights.
+
     The points closest to the budget are used to estimate the initial guess. They also
     have the highest weight.
 
@@ -323,8 +324,7 @@ def exponential(prices: np.ndarray, emissions: np.ndarray, budget: int) -> float
 def exp_guess_and_weights(
     prices: np.ndarray, emissions: np.ndarray, budget: int
 ) -> tuple:
-    """Estimates initial values for the exponential fitting algorithm and the
-    weights.
+    """Estimates initial values for the exponential fitting algorithm and the weights.
 
     The points closest to the budget are used to estimate the initial guess. They also
     have the highest weight.
@@ -374,9 +374,9 @@ def bisection(
     price_too_high_threshold: float = 10,
     fitter: Text = "slinear",
 ) -> float:
-    """
-    Applies bisection algorithm to escalate carbon price and
-    meet the budget. A carbon market is meant as a pool of emissions for all
+    """Applies bisection algorithm to escalate carbon price and meet the budget.
+
+    A carbon market is meant as a pool of emissions for all
     the modelled regions; therefore, the carbon price applies to all modelled regions.
     Bisection applies an iterative estimations of the emissions
     varying the carbon price until convergence or stop criteria
@@ -386,7 +386,7 @@ def bisection(
     Arguments:
         market: Market, with the prices, supply, consumption and demand,
         sectors: List of sectors,
-        equilibrium: Method for searching maerket equilibrium,
+        equilibrium: Method for searching market equilibrium,
         carbon_budget: DataArray with the carbon budget,
         carbon_price: DataArray with the carbon price,
         commodities: List of carbon-related commodities,
@@ -498,9 +498,10 @@ def min_max_bisect(
     threshold: float,
 ):
     """Refines bisection algorithm to escalate carbon price and meet the budget.
-    As emissions can be a discontinuous function of the carbon price,
-    this method is used to improve the solution search when discountinuities
-    are met, improving the bounds search.
+
+    As emissions can be a discontinuous function of the carbon price, this method is
+    used to improve the solution search when discontinuities are met, improving the
+    bounds search.
 
     Arguments:
         low: Value of carbon price at lower bound,
@@ -509,7 +510,7 @@ def min_max_bisect(
         ub: Value of emissions at upper bound,
         market: Market, with the prices, supply, consumption and demand,
         sectors: List of sectors,
-        equilibrium: Method for searching maerket equilibrium,
+        equilibrium: Method for searching market equilibrium,
         commodities: List of carbon-related commodities,
         sample_size: Number of iterations for bisection,
         refine_price: Boolean to decide on whether carbon price should be refined,
@@ -579,13 +580,14 @@ def bisect_loop(
     commodities: list,
     new_price: float,
 ) -> float:
-    """Calls market euilibrium iteration in bisection.
+    """Calls market equilibrium iteration in bisection.
+
     This updates emissions during iterations.
 
     Arguments:
         market: Market, with the prices, supply, consumption and demand,
         sectors: List of sectors,
-        equilibrium: Method for searching maerket equilibrium,
+        equilibrium: Method for searching market equilibrium,
         commodities: List of carbon-related commodities,
         new_price: New carbon price from bisection,
 

--- a/src/muse/commodities.py
+++ b/src/muse/commodities.py
@@ -125,7 +125,6 @@ def check_usage(
             - "exact", should match each flag and nothing else.
 
     Examples:
-
         >>> from muse.commodities import CommodityUsage, check_usage
         >>> data = [
         ...     CommodityUsage.OTHER,
@@ -207,7 +206,6 @@ def is_pollutant(data: Sequence[CommodityUsage]) -> ndarray:
     """Environmental product.
 
     Examples:
-
         >>> from muse.commodities import CommodityUsage, is_pollutant
         >>> data = [
         ...     CommodityUsage.CONSUMABLE,
@@ -228,7 +226,6 @@ def is_consumable(data: Sequence[CommodityUsage]) -> ndarray:
     """Any consumable.
 
     Examples:
-
         >>> from muse.commodities import CommodityUsage, is_consumable
         >>> data = [
         ...     CommodityUsage.CONSUMABLE,
@@ -247,7 +244,6 @@ def is_fuel(data: Sequence[CommodityUsage]) -> ndarray:
     """Any consumable energy.
 
     Examples:
-
         >>> from muse.commodities import CommodityUsage, is_fuel
         >>> data = [
         ...     CommodityUsage.CONSUMABLE,
@@ -270,7 +266,6 @@ def is_material(data: Sequence[CommodityUsage]) -> ndarray:
     """Any non-energy non-environmental consumable.
 
     Examples:
-
         >>> from muse.commodities import CommodityUsage, is_material
         >>> data = [
         ...     CommodityUsage.CONSUMABLE,
@@ -299,7 +294,6 @@ def is_enduse(data: Sequence[CommodityUsage]) -> ndarray:
     """Non-environmental product.
 
     Examples:
-
         >>> from muse.commodities import CommodityUsage, is_enduse
         >>> data = [
         ...     CommodityUsage.CONSUMABLE,
@@ -323,7 +317,6 @@ def is_other(data: Sequence[CommodityUsage]) -> ndarray:
     """No flags are set.
 
     Examples:
-
         >>> from muse.commodities import CommodityUsage, is_other
         >>> data = [
         ...     CommodityUsage.OTHER,

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -1,4 +1,4 @@
-"""Investment constraints.
+r"""Investment constraints.
 
 Constraints on investements ensure that investements match some given criteria. For
 instance, the constraints could ensure that only so much of a new asset can be built
@@ -557,7 +557,6 @@ def lp_costs(
     """Creates costs for solving with scipy's LP solver.
 
     Example:
-
         We can now construct example inputs to the function from the sample model. The
         costs will be a matrix where each assets has a candidate replacement technology.
 
@@ -734,8 +733,7 @@ def lp_constraint_matrix(
      The result is the constraint matrix, expanded, reduced and diagonalized for the
      conditions above.
 
-     Example:
-
+    Example:
          Lets first setup a constraint and a cost matrix:
 
          >>> from muse import examples
@@ -861,7 +859,6 @@ class ScipyAdapter:
     """Creates the input for the scipy solvers.
 
     Example:
-
         Lets give a fist simple example. The constraint
         :py:func:`~muse.constraints.max_capacity_expansion` limits how much each
         capacity can be expanded in a given year.

--- a/src/muse/decisions.py
+++ b/src/muse/decisions.py
@@ -232,7 +232,7 @@ def retro_lexical_comparison(
 def _epsilon_constraints(
     objectives: Dataset, optimize: Text, mask: Optional[Any] = None, **epsilons
 ) -> DataArray:
-    """minimizes one objective subject to constraints on other objectives."""
+    """Minimizes one objective subject to constraints on other objectives."""
     constraints = True
     for name, epsilon in epsilons.items():
         reduced_dims = set(objectives[name].dims) - {"asset", "replacement"}

--- a/src/muse/demand_matching.py
+++ b/src/muse/demand_matching.py
@@ -169,6 +169,7 @@ def demand_matching(
             as `max_production`.
         cost: Cost to minimize while fulfilling the demand.
         *constraints: each item is a separate constraint :math:`M_r`.
+        protected_dims: Dimensions that will not be modified
 
     Returns:
         An array with the joint dimensionality of `max_production`, `cost`, and

--- a/src/muse/demand_share.py
+++ b/src/muse/demand_share.py
@@ -135,6 +135,9 @@ def new_and_retro(
             to the production method. The ``consumption`` reflects the demand for the
             commodities produced by the current sector.
         technologies: quantities describing the technologies.
+        production: Production method
+        current_year: Current year of simulation
+        forecast: How many years to forecast ahead
 
     Pseudo-code:
 
@@ -343,6 +346,9 @@ def standard_demand(
             to the production method. The ``consumption`` reflects the demand for the
             commodities produced by the current sector.
         technologies: quantities describing the technologies.
+        production: Production method
+        current_year: Current year of simulation
+        forecast: How many years to forecast ahead
 
     """
     from functools import partial

--- a/src/muse/errors.py
+++ b/src/muse/errors.py
@@ -36,7 +36,7 @@ and/or the MaxCapacityGrowth in the technodata."""
 
 
 class TechnologyNotDefined(Exception):
-    """Indicates that the initialisation fails because a technology is not found"""
+    """Indicates that the initialisation fails because a technology is not found."""
 
     msg = """Error during the initialisation of a sector.
 The model tries to assign a share of the total capacity to an agent but it
@@ -48,7 +48,7 @@ Check the spelling of the technology names."""
 
 
 class FailedInterpolation(Exception):
-    """Indicates that the initialisation fails due to interpolation"""
+    """Indicates that the initialisation fails due to interpolation."""
 
     msg = """Error during the initialisation of a sector.
 The model tries to interpolate values in time of the technologies.

--- a/src/muse/examples.py
+++ b/src/muse/examples.py
@@ -39,14 +39,14 @@ __all__ = ["model", "technodata"]
 
 
 def example_data_dir() -> Path:
-    """Gets the examples folder"""
+    """Gets the examples folder."""
     import muse
 
     return Path(muse.__file__).parent / "data" / "example"
 
 
 def available_examples() -> List[str]:
-    """List examples available in the examples folder"""
+    """List examples available in the examples folder."""
     return [d.stem for d in example_data_dir().iterdir() if d.is_dir()]
 
 
@@ -134,7 +134,6 @@ def search_space(sector: Text, model: Text = "default") -> xr.DataArray:
 
     Used in constraints or during investment.
     """
-
     if model == "trade" and sector != "residential":
         return _trade_search_space(sector, model)
     return _nontrade_search_space(sector, model)

--- a/src/muse/interactions.py
+++ b/src/muse/interactions.py
@@ -89,7 +89,6 @@ def factory(
     inputs: Optional[Sequence[Union[Mapping, Tuple[Text, Text]]]] = None,
 ) -> Callable[[Sequence[AbstractAgent]], None]:
     """Creates an interaction functor."""
-
     if inputs is None:
         inputs = tuple()
 

--- a/src/muse/investments.py
+++ b/src/muse/investments.py
@@ -204,6 +204,7 @@ def cliff_retirement_profile(
         current_year: current year
         protected: The technologies are assumed to be renewed between years
             `current_year` and `current_year + protected`
+        interpolation: Interpolation type
         **kwargs: arguments by which to filter technical_life, if any.
 
     Returns:

--- a/src/muse/mca.py
+++ b/src/muse/mca.py
@@ -200,6 +200,8 @@ class MCA(object):
 
         Arguments:
             market: Commodities market, with the prices, supply, consumption and demand.
+            sectors: A list of the sectors participating in the simulation.
+            maxiter: Maximum number of iterations.
 
         Returns:
             A tuple with the updated market (prices, supply, consumption and demand) and
@@ -368,8 +370,9 @@ class MCA(object):
             )
 
     def calibrate_legacy_sectors(self):
-        """Run a calibration step in the legacy sectors
-        Run historical years
+        """Run a calibration step in the legacy sectors.
+
+        Run historical years.
         """
         from copy import deepcopy
         from logging import getLogger

--- a/src/muse/objectives.py
+++ b/src/muse/objectives.py
@@ -485,7 +485,7 @@ def annual_levelized_cost_of_energy(
 
     Arguments:
         agent: The agent of interest
-        demand: Demand for technology
+        demand: Demand for commodities
         search_space: The search space space for replacement technologies
         technologies: All the technologies
         market: The market parameters
@@ -548,7 +548,7 @@ def lifetime_levelized_cost_of_energy(
 
     Arguments:
         agent: The agent of interest
-        demand: Demand for technology
+        demand: Demand for commodities
         search_space: The search space space for replacement technologies
         technologies: All the technologies
         market: The market parameters
@@ -707,7 +707,7 @@ def net_present_value(
 
     Arguments:
         agent: The agent of interest
-        demand: Demand for technology
+        demand: Demand for commodities
         search_space: The search space space for replacement technologies
         technologies: All the technologies
         market: The market parameters
@@ -901,7 +901,7 @@ def equivalent_annual_cost(
 
     Arguments:
         agent: The agent of interest
-        demand: Demand for technology
+        demand: Demand for commodities
         search_space: The search space space for replacement technologies
         technologies: All the technologies
         market: The market parameters

--- a/src/muse/objectives.py
+++ b/src/muse/objectives.py
@@ -479,15 +479,18 @@ def annual_levelized_cost_of_energy(
     **kwargs,
 ):
     """Annual cost of energy (LCOE) of technologies - not dependent on production.
-    It needs to be used for trade agents where the actual service is unknown
 
-    It follows the `simplified LCOE` given by NREL.
+    It needs to be used for trade agents where the actual service is unknown. It follows
+    the `simplified LCOE` given by NREL.
 
     Arguments:
         agent: The agent of interest
+        demand: Demand for technology
         search_space: The search space space for replacement technologies
         technologies: All the technologies
         market: The market parameters
+        *args: Extra arguments (unused)
+        **kwargs: Extra keyword arguments (unused)
 
     Return:
         xr.DataArray with the LCOE calculated for the relevant technologies
@@ -519,7 +522,6 @@ def capital_recovery_factor(
     Return:
         xr.DataArray with the CRF calculated for the relevant technologies
     """
-
     tech = agent.filter_input(
         technologies[["technical_life", "interest_rate"]],
         technology=search_space.replacement,
@@ -546,9 +548,12 @@ def lifetime_levelized_cost_of_energy(
 
     Arguments:
         agent: The agent of interest
+        demand: Demand for technology
         search_space: The search space space for replacement technologies
         technologies: All the technologies
         market: The market parameters
+        *args: Extra arguments (unused)
+        **kwargs: Extra keyword arguments (unused)
 
     Return:
         xr.DataArray with the LCOE calculated for the relevant technologies
@@ -702,9 +707,12 @@ def net_present_value(
 
     Arguments:
         agent: The agent of interest
+        demand: Demand for technology
         search_space: The search space space for replacement technologies
         technologies: All the technologies
         market: The market parameters
+        *args: Extra arguments (unused)
+        **kwargs: Extra keyword arguments (unused)
 
     Return:
         xr.DataArray with the NPV calculated for the relevant technologies
@@ -893,9 +901,12 @@ def equivalent_annual_cost(
 
     Arguments:
         agent: The agent of interest
+        demand: Demand for technology
         search_space: The search space space for replacement technologies
         technologies: All the technologies
         market: The market parameters
+        *args: Extra arguments (unused)
+        **kwargs: Extra keyword arguments (unused)
 
     Return:
         xr.DataArray with the EAC calculated for the relevant technologies

--- a/src/muse/outputs/cache.py
+++ b/src/muse/outputs/cache.py
@@ -1,4 +1,4 @@
-"""Output cached quantities
+"""Output cached quantities.
 
 Functions that output the state of diverse quantities at intermediate steps of the
 calculation.
@@ -328,7 +328,7 @@ class OutputCache:
 def extract_agents(
     sectors: List[AbstractSector],
 ) -> MutableMapping[Text, MutableMapping[Text, Text]]:
-    """_summary_
+    """_summary_.
 
     Args:
         sectors (List[AbstractSector]): _description_
@@ -372,11 +372,11 @@ def _aggregate_cache(quantity: Text, data: List[xr.DataArray]) -> pd.DataFrame:
 
     The merging gives precedence to the last entries of the list over the first ones.
     I.e, the records of the arrays cached last will overwrite those of the ones cached
-    before in the case of having dientical index.
+    before in the case of having identical index.
 
     Args:
-        quantity (Text): The quantity to cache.
-        data List[xr.DataArray]: The list of DataArrays to combine.
+        quantity: The quantity to cache.
+        data: The list of DataArrays to combine.
 
     Returns:
         pd.DataFrame: A Dataframe with the data aggregated.

--- a/src/muse/outputs/mca.py
+++ b/src/muse/outputs/mca.py
@@ -247,7 +247,6 @@ def _aggregate_sectors(
     sectors: List[AbstractSector], *args, op: Callable
 ) -> pd.DataFrame:
     """Aggregate outputs from all sectors."""
-
     alldata = [op(sector, *args) for sector in sectors]
 
     if len(alldata) == 0:
@@ -794,7 +793,6 @@ def sector_capital_costs(
     sector: AbstractSector, market: xr.Dataset, **kwargs
 ) -> pd.DataFrame:
     """Sector capital costs with agent annotations."""
-
     data_sector: List[xr.DataArray] = []
     technologies = getattr(sector, "technologies", [])
     agents = sorted(getattr(sector, "agents", []), key=attrgetter("name"))
@@ -912,7 +910,6 @@ def metric_lcoe(
 
 def sector_lcoe(sector: AbstractSector, market: xr.Dataset, **kwargs) -> pd.DataFrame:
     """Levelized cost of energy () of technologies over their lifetime."""
-
     from muse.commodities import is_enduse, is_fuel, is_material, is_pollutant
     from muse.objectives import discount_factor
     from muse.quantities import consumption
@@ -1115,7 +1112,6 @@ def metric_eac(
 
 def sector_eac(sector: AbstractSector, market: xr.Dataset, **kwargs) -> pd.DataFrame:
     """Net Present Value of technologies over their lifetime."""
-
     from muse.commodities import is_enduse, is_fuel, is_material, is_pollutant
     from muse.objectives import discount_factor
     from muse.quantities import consumption

--- a/src/muse/outputs/sector.py
+++ b/src/muse/outputs/sector.py
@@ -202,7 +202,6 @@ def supply(
     rounding: int = 4,
 ) -> xr.DataArray:
     """Current supply."""
-
     moutput = market.copy(deep=True).reset_index("timeslice")
     result = (
         market_quantity(moutput.supply, sum_over=sum_over, drop=drop)

--- a/src/muse/production.py
+++ b/src/muse/production.py
@@ -71,7 +71,7 @@ def factory(
     actual functor usable within the model, i.e. it converts data into logic.
 
     Arguments:
-        name: Registered production method to create. The name is resolved when the
+        settings: Registered production method to create. The name is resolved when the
             function returned by the factory is called. Hence, it could refer to a
             function yet to be registered when this factory method is called.
         **kwargs: any keyword argument the production method accepts.
@@ -165,12 +165,12 @@ def costed_production(
     with_emission: bool = True,
 ) -> xr.DataArray:
     """Computes production from ranked assets.
+
     The assets are ranked according to their cost. The cost can be provided as an
     xarray, a callable creating an xarray, or as "alcoe". The asset with least cost are
     allowed to service the demand first, up to the maximum production. By default, the
     minimum service is applied first.
     """
-
     from muse.commodities import CommodityUsage, check_usage, is_pollutant
     from muse.quantities import (
         annual_levelized_cost_of_energy,

--- a/src/muse/quantities.py
+++ b/src/muse/quantities.py
@@ -30,9 +30,11 @@ def supply(
     Arguments:
         capacity: number/quantity of assets that can service the demand
         demand: amount of each end-use required. The supply of each process will not
-            exceed it's share of the demand.
+            exceed its share of the demand.
         technologies: factors bindings the capacity of an asset with its production of
             commodities and environmental pollutants.
+        interpolation: Interpolation type
+        production_method: Production for a given capacity
 
     Return:
         A data array where the commodity dimension only contains actual outputs (i.e. no
@@ -133,7 +135,8 @@ def emission(production: xr.DataArray, fixed_outputs: xr.DataArray):
 def gross_margin(
     technologies: xr.Dataset, capacity: xr.DataArray, prices: xr.Dataset
 ) -> xr.DataArray:
-    """The percentage of revenue after direct expenses have been subtracted
+    """The percentage of revenue after direct expenses have been subtracted.
+
     .. _reference:
     https://www.investopedia.com/terms/g/grossmargin.asp
     We first calculate the revenues, which depend on prices
@@ -141,7 +144,7 @@ def gross_margin(
     - energy commodities INPUTS are related to fuel costs
     - environmental commodities OUTPUTS are related to environmental costs
     - variable costs is given as technodata inputs
-    - non-environmental commodities OUTPUTS are related to revenues
+    - non-environmental commodities OUTPUTS are related to revenues.
     """
     from muse.commodities import is_enduse, is_pollutant
     from muse.timeslices import QuantityType, convert_timeslice
@@ -441,6 +444,7 @@ def maximum_production(technologies: xr.Dataset, capacity: xr.DataArray, **filte
             technologies. Filters not relevant to the quantities of interest, i.e.
             filters that are not a dimension of `capacity` or `technologies`, are
             silently ignored.
+
     Return:
         `capacity * fixed_outputs * utilization_factor`, whittled down according to the
         filters and the set of technologies in `capacity`.
@@ -474,6 +478,7 @@ def demand_matched_production(
         demand: demand to match.
         prices: price from which to compute the annual levelized cost of energy.
         capacity: capacity from which to obtain the maximum production constraints.
+        technologies: technologies we are looking at
         **filters: keyword arguments with which to filter the input datasets and
             data arrays., e.g. region, or year.
     """
@@ -513,6 +518,7 @@ def capacity_in_use(
             technologies. Filters not relevant to the quantities of interest, i.e.
             filters that are not a dimension of `capacity` or `technologies`, are
             silently ignored.
+
     Return:
         Capacity-in-use for each technology, whittled down by the filters.
     """
@@ -582,11 +588,11 @@ def costed_production(
     with_minimum_service: bool = True,
 ) -> xr.DataArray:
     """Computes production from ranked assets.
+
     The assets are ranked according to their cost. The asset with least cost are allowed
     to service the demand first, up to the maximum production. By default, the minimum
     service is applied first.
     """
-
     from muse.quantities import maximum_production
     from muse.timeslices import QuantityType, convert_timeslice
     from muse.utilities import broadcast_techs

--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -210,7 +210,6 @@ def read_io_technodata(filename: Union[Text, Path]) -> xr.Dataset:
 
 def read_initial_assets(filename: Union[Text, Path]) -> xr.DataArray:
     """Reads and formats data about initial capacity into a dataframe."""
-
     data = pd.read_csv(filename, float_precision="high", low_memory=False)
     if "Time" in data.columns:
         result = cast(
@@ -883,7 +882,6 @@ def read_trade(
 
 def read_finite_resources(path: Union[Text, Path]) -> xr.DataArray:
     """Reads finite resources from csv file.
-
 
     The CSV file is made up of columns "Region", "Year", as well
     as three timeslice columns ("Month", "Day", "Hour"). All three sets of columns are

--- a/src/muse/readers/toml.py
+++ b/src/muse/readers/toml.py
@@ -406,14 +406,14 @@ def read_ts_multiindex(
     timeslice: Optional[xr.DataArray] = None,
     transforms: Optional[Dict[Tuple, np.ndarray]] = None,
 ) -> pd.MultiIndex:
-    r"""Read multiindex for a timeslice from TOML.
+    '''Read multiindex for a timeslice from TOML.
 
     Example:
         The timeslices are read from ``timeslice_levels``. The levels (keyword) and
         slice (list of values) correspond to the level, slices and slice aggregates
         defined  in the the ``timeslices`` section.
 
-        >>> toml = \"\"\"
+        >>> toml = """
         ...     ["timeslices"]
         ...     winter.weekday.day = 5
         ...     winter.weekday.night = 5
@@ -429,7 +429,7 @@ def read_ts_multiindex(
         ...     aggregates.allday = ["day", "night"]
         ...     [timeslice_levels]
         ...     day = ["dusk", "allday"]
-        ... \"\"\"
+        ... """
         >>> from muse.timeslices import (
         ...     reference_timeslice,  aggregate_transforms
         ... )
@@ -455,7 +455,7 @@ def read_ts_multiindex(
         Traceback (most recent call last):
         ...
         muse.readers.toml.IncorrectSettings: Unexpected slice(s): ...
-    """
+    '''
     from itertools import product
 
     from toml import loads
@@ -498,7 +498,7 @@ def read_timeslices(
     timeslice: Optional[xr.DataArray] = None,
     transforms: Optional[Dict[Tuple, np.ndarray]] = None,
 ) -> xr.Dataset:
-    r"""Reads timeslice levels and create resulting timeslice coordinate.
+    '''Reads timeslice levels and create resulting timeslice coordinate.
 
     Args:
         settings: TOML dictionary. It should contain a ``timeslice_levels`` section.
@@ -516,7 +516,7 @@ def read_timeslices(
         A xr.Dataset with the timeslice coordinates.
 
     Example:
-        >>> toml = \"\"\"
+        >>> toml = """
         ...     ["timeslices"]
         ...     winter.weekday.day = 5
         ...     winter.weekday.night = 5
@@ -532,7 +532,7 @@ def read_timeslices(
         ...     aggregates.allday = ["day", "night"]
         ...     [timeslice_levels]
         ...     day = ["dusk", "allday"]
-        ... \"\"\"
+        ... """
         >>> from muse.timeslices import (
         ...     reference_timeslice,  aggregate_transforms
         ... )
@@ -550,7 +550,7 @@ def read_timeslices(
             represent_hours  (timeslice) ... 10 1 4 10 1 4
         Data variables:
             *empty*
-    """
+    '''
     from muse.timeslices import TIMESLICE, timeslice_projector
 
     if timeslice is None:

--- a/src/muse/readers/toml.py
+++ b/src/muse/readers/toml.py
@@ -127,7 +127,6 @@ def format_paths(
     nested dictionaries.
 
     Examples:
-
         Starting from a simple example, we see `data_path` has been modified to point to
         the current working directory:
 
@@ -356,12 +355,13 @@ def read_settings(
     """Loads the input settings for any MUSE simulation.
 
     Loads a MUSE settings file. This must be a TOML formatted file. Missing settings are
-    loaded from the DEFAULT_SETTINGS. Custom pythom modules, if present, are loaded
+    loaded from the DEFAULT_SETTINGS. Custom Python modules, if present, are loaded
     and checks are run to validate the settings and ensure that they are compatible with
     a MUSE simulation.
 
     Arguments:
-    settings_file: A string or a Path to the settings file
+        settings_file: A string or a Path to the settings file
+        path: A string or path to the settings folder
 
     Returns:
         A dictionary with the settings
@@ -406,10 +406,9 @@ def read_ts_multiindex(
     timeslice: Optional[xr.DataArray] = None,
     transforms: Optional[Dict[Tuple, np.ndarray]] = None,
 ) -> pd.MultiIndex:
-    """Read multiindex for a timeslice from TOML.
+    r"""Read multiindex for a timeslice from TOML.
 
     Example:
-
         The timeslices are read from ``timeslice_levels``. The levels (keyword) and
         slice (list of values) correspond to the level, slices and slice aggregates
         defined  in the the ``timeslices`` section.
@@ -499,7 +498,7 @@ def read_timeslices(
     timeslice: Optional[xr.DataArray] = None,
     transforms: Optional[Dict[Tuple, np.ndarray]] = None,
 ) -> xr.Dataset:
-    """Reads timeslice levels and create resulting timeslice coordinate.
+    r"""Reads timeslice levels and create resulting timeslice coordinate.
 
     Args:
         settings: TOML dictionary. It should contain a ``timeslice_levels`` section.
@@ -512,6 +511,7 @@ def read_timeslices(
             to the global in :py:mod:`~muse.timeslices`. If using the default,
             then this function should be called *after* the timeslice module has been
             setup with a call to :py:func:`~muse.timeslice.setup_module`.
+
     Returns:
         A xr.Dataset with the timeslice coordinates.
 
@@ -631,7 +631,6 @@ def add_unknown_parameters(dd, u):
 
 def validate_settings(settings: Dict) -> None:
     """Run the checks on the settings file."""
-
     msg = " Validating input settings..."
     getLogger(__name__).info(msg)
 
@@ -678,7 +677,6 @@ def check_plugins(settings: Dict) -> None:
 @register_settings_check(vary_name=False)
 def check_log_level(settings: Dict) -> None:
     """Check the log level required in the simulation."""
-
     valid_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     msg = "ERROR - Valid log levels are {}.".format(", ".join(valid_levels))
     assert settings["log_level"].upper() in valid_levels, msg
@@ -789,7 +787,6 @@ def check_time_slices(settings: Dict) -> None:
 @register_settings_check(vary_name=False)
 def check_global_data_files(settings: Dict) -> None:
     """Checks that the global user files exist."""
-
     user_data = settings["global_input_files"]
 
     if Path(user_data["path"]).is_absolute():
@@ -822,7 +819,6 @@ def check_global_data_files(settings: Dict) -> None:
 @register_settings_check(vary_name=False)
 def check_sectors_files(settings: Dict) -> None:
     """Checks that the sector files exist."""
-
     sectors = settings["sectors"]
     priorities = {
         "preset": 0,

--- a/src/muse/regressions.py
+++ b/src/muse/regressions.py
@@ -34,7 +34,6 @@ class Regression(Callable):
     All regression functors are derived from this object.
 
     Examples:
-
     Creating a regression function can be done via it's constructor, or
     through a input csv file. This file is a
 
@@ -391,7 +390,7 @@ def ExponentialAdj(
 def Logistic(
     self, gdp: DataArray, population: DataArray, forecast: int = 5, n: int = 4, **kwargs
 ) -> DataArray:
-    """(1 + t * f^n) / (1 + f^n) * a * pop / (1 + b * e^(gpd * c / pop))
+    """(1 + t * f^n) / (1 + f^n) * a * pop / (1 + b * e^(gpd * c / pop)).
 
     With f the number of forecast years.
     """
@@ -406,7 +405,7 @@ def Logistic(
 @register_regression(name="log-log")
 @regression_functor({"a": "constant", "b": "GDPexp"})
 def Loglog(self, gdp: DataArray, population: DataArray, *args, **kwargs) -> DataArray:
-    """1e6 * e^a * population * (gpd/population)^b"""
+    """1e6 * e^a * population * (gpd/population)^b."""
     from numpy import exp, power
 
     factor = 1e6 * exp(self.coeffs.a) * population
@@ -425,7 +424,7 @@ def LogisticSigmoid(
     year: Optional[Union[int, Sequence[int]]] = None,
     **kwargs,
 ) -> DataArray:
-    """0.001 * (constant * pop + gdp * c / sqrt(1 + (gdp * scale / pop)^2)"""
+    """0.001 * (constant * pop + gdp * c / sqrt(1 + (gdp * scale / pop)^2)."""
     from numpy import power
 
     constant = self.coeffs.a
@@ -453,7 +452,7 @@ def LogisticSigmoid(
 
 @register_regression
 class Linear(Regression):
-    """a * population + b * (gdp - gdp[2010]/population[2010] * population)"""
+    """a * population + b * (gdp - gdp[2010]/population[2010] * population)."""
 
     __mappings__ = {"a": "constant", "b0": "GDPscaleLess", "b1": "GDPscaleGreater"}
 

--- a/src/muse/sectors/legacy_sector.py
+++ b/src/muse/sectors/legacy_sector.py
@@ -1,7 +1,7 @@
-"""This module defines the LegacySector class, needed to interface the new MCA
-with the old MUSE sectors.
+"""This module defines the LegacySector class.
 
-It can be deleted once accessing those sectors is no longer needed.
+This is needed to interface the new MCA with the old MUSE sectors. It can be deleted
+once accessing those sectors is no longer needed.
 """
 
 from dataclasses import dataclass
@@ -320,7 +320,6 @@ class LegacySector(AbstractSector):  # type: ignore
 
     def _to(self, data: np.ndarray, data_ts, ts: pd.MultiIndex, qt: QuantityType):
         """From ndarray to dataarray."""
-
         return ndarray_to_xarray(
             years=self.time_framework,
             data=data,
@@ -335,7 +334,6 @@ class LegacySector(AbstractSector):  # type: ignore
 
     def _from(self, xdata: DataArray, ts: pd.MultiIndex, qt: QuantityType):
         """From dataarray to ndarray."""
-
         return xarray_to_ndarray(
             years=self.time_framework,
             xdata=xdata,
@@ -427,8 +425,7 @@ def xarray_to_ndarray(
 
 
 def commodities_idx(sector, comm: Text) -> Sequence:
-    """Gets the indices of the commodities involved in the processes of the
-    sector.
+    """Gets the indices of the commodities involved in the processes of the sector.
 
     Arguments:
         sector: The old MUSE sector of interest
@@ -437,7 +434,6 @@ def commodities_idx(sector, comm: Text) -> Sequence:
     Returns:
         A list with the indexes
     """
-
     comm = {
         "OUT": "listIndexCommoditiesOUT",
         "IN": "listIndexCommoditiesIN",

--- a/src/muse/sectors/preset_sector.py
+++ b/src/muse/sectors/preset_sector.py
@@ -167,7 +167,6 @@ class PresetSector(AbstractSector):  # type: ignore
 
     def _interpolate(self, data: DataArray, years: DataArray) -> DataArray:
         """Chooses interpolation depending on whether forecast is available."""
-
         if "forecast" in data.dims:
             baseyear = int(years.min())
             forecasted = (years - baseyear).values

--- a/src/muse/sectors/register.py
+++ b/src/muse/sectors/register.py
@@ -13,7 +13,6 @@ def register_sector(
     """Registers a sector so it is available MUSE-wide.
 
     Example:
-
         >>> from muse.sectors import AbstractSector, register_sector
         >>> @register_sector(name="MyResidence")
         ... class ResidentialSector(AbstractSector):

--- a/src/muse/sectors/sector.py
+++ b/src/muse/sectors/sector.py
@@ -188,6 +188,7 @@ class Sector(AbstractSector):  # type: ignore
             time_period:
                 Length of the time period in the framework. Defaults to the range of
                 ``mca_market.year``.
+            current_year: Current year of the simulation
 
         Returns:
             A market containing the ``supply`` offered by the sector, it's attendant

--- a/src/muse/timeslices.py
+++ b/src/muse/timeslices.py
@@ -71,7 +71,7 @@ def reference_timeslice(
     level_names: Sequence[Text] = ("month", "day", "hour"),
     name: Text = "timeslice",
 ) -> DataArray:
-    """Reads reference timeslice from toml like input.
+    r"""Reads reference timeslice from toml like input.
 
     Arguments:
         settings: A dictionary of nested dictionaries or a string that toml will
@@ -89,7 +89,6 @@ def reference_timeslice(
         weight of each timeslice.
 
     Example:
-
         >>> from muse.timeslices import reference_timeslice
         >>> reference_timeslice(
         ...     \"\"\"
@@ -150,7 +149,7 @@ def aggregate_transforms(
     settings: Optional[Union[Mapping, Text]] = None,
     timeslice: Optional[DataArray] = None,
 ) -> Dict[Tuple, ndarray]:
-    """Creates dictionary of transforms for aggregate levels.
+    r"""Creates dictionary of transforms for aggregate levels.
 
     The transforms are used to create the projectors towards the finest timeslice.
 
@@ -165,7 +164,6 @@ def aggregate_transforms(
         timeslices.
 
     Example:
-
         >>> toml = \"\"\"
         ...     [timeslices]
         ...     spring.weekday = 5
@@ -251,14 +249,13 @@ def timeslice_projector(
     finest: Optional[DataArray] = None,
     transforms: Optional[Dict[Tuple, ndarray]] = None,
 ) -> DataArray:
-    """Project time-slice to standardized finest time-slices.
+    r"""Project time-slice to standardized finest time-slices.
 
     Returns a matrix from the input timeslice ``x`` to the ``finest`` timeslice, using
     the input ``transforms``. The latter are a set of transforms that map indices from
     one timeslice to indices in another.
 
     Example:
-
         Lets define the following timeslices and aggregates:
 
         >>> toml = \"\"\"
@@ -405,7 +402,7 @@ def convert_timeslice(
     finest: Optional[DataArray] = None,
     transforms: Optional[Dict[Tuple, ndarray]] = None,
 ) -> Union[DataArray, Dataset]:
-    """Adjusts the timeslice of x to match that of ts.
+    r"""Adjusts the timeslice of x to match that of ts.
 
     The conversion can be done in on of two ways, depending on whether the
     quantity is extensive or intensive. See `QuantityType`.
@@ -564,7 +561,6 @@ def new_to_old_timeslice(ts: DataArray, ag_level="Month") -> dict:
     This function is used in the LegacySector class to adapt the new MCA timeslices to
     the format required by the old sectors.
     """
-
     length = len(ts.month.values)
     converted_ts = {
         "Month": [kebab_to_camel(w) for w in ts.month.values],

--- a/src/muse/timeslices.py
+++ b/src/muse/timeslices.py
@@ -71,7 +71,7 @@ def reference_timeslice(
     level_names: Sequence[Text] = ("month", "day", "hour"),
     name: Text = "timeslice",
 ) -> DataArray:
-    r"""Reads reference timeslice from toml like input.
+    '''Reads reference timeslice from toml like input.
 
     Arguments:
         settings: A dictionary of nested dictionaries or a string that toml will
@@ -91,7 +91,7 @@ def reference_timeslice(
     Example:
         >>> from muse.timeslices import reference_timeslice
         >>> reference_timeslice(
-        ...     \"\"\"
+        ...     """
         ...     [timeslices]
         ...     spring.weekday = 5
         ...     spring.weekend = 2
@@ -102,7 +102,7 @@ def reference_timeslice(
         ...     summer.weekday = 5
         ...     summer.weekend = 2
         ...     level_names = ["season", "week"]
-        ...     \"\"\"
+        ...     """
         ... )
         <xarray.DataArray (timeslice: 8)>
         array([5, 2, 5, 2, 5, 2, 5, 2])
@@ -110,7 +110,7 @@ def reference_timeslice(
           * timeslice  (timeslice) MultiIndex
           - season     (timeslice) object 'spring' 'spring' ... 'summer' 'summer'
           - week       (timeslice) object 'weekday' 'weekend' ... 'weekday' 'weekend'
-    """
+    '''
     from functools import reduce
     from typing import List, Tuple
 
@@ -149,7 +149,7 @@ def aggregate_transforms(
     settings: Optional[Union[Mapping, Text]] = None,
     timeslice: Optional[DataArray] = None,
 ) -> Dict[Tuple, ndarray]:
-    r"""Creates dictionary of transforms for aggregate levels.
+    '''Creates dictionary of transforms for aggregate levels.
 
     The transforms are used to create the projectors towards the finest timeslice.
 
@@ -164,7 +164,7 @@ def aggregate_transforms(
         timeslices.
 
     Example:
-        >>> toml = \"\"\"
+        >>> toml = """
         ...     [timeslices]
         ...     spring.weekday = 5
         ...     spring.weekend = 2
@@ -178,7 +178,7 @@ def aggregate_transforms(
         ...     [timeslices.aggregates]
         ...     spautumn = ["spring", "autumn"]
         ...     week = ["weekday", "weekend"]
-        ... \"\"\"
+        ... """
         >>> from muse.timeslices import reference_timeslice, aggregate_transforms
         >>> ref = reference_timeslice(toml)
         >>> transforms = aggregate_transforms(toml, ref)
@@ -190,7 +190,7 @@ def aggregate_transforms(
         array([0, 0, 1, 1, 0, 0, 0, 0])
         >>> transforms[("spautumn", "week")].T
         array([1, 1, 1, 1, 0, 0, 0, 0])
-    """
+    '''
     from itertools import product
 
     from numpy import identity, sum
@@ -249,7 +249,7 @@ def timeslice_projector(
     finest: Optional[DataArray] = None,
     transforms: Optional[Dict[Tuple, ndarray]] = None,
 ) -> DataArray:
-    r"""Project time-slice to standardized finest time-slices.
+    '''Project time-slice to standardized finest time-slices.
 
     Returns a matrix from the input timeslice ``x`` to the ``finest`` timeslice, using
     the input ``transforms``. The latter are a set of transforms that map indices from
@@ -258,7 +258,7 @@ def timeslice_projector(
     Example:
         Lets define the following timeslices and aggregates:
 
-        >>> toml = \"\"\"
+        >>> toml = """
         ...     ["timeslices"]
         ...     winter.weekday.day = 5
         ...     winter.weekday.night = 5
@@ -272,7 +272,7 @@ def timeslice_projector(
         ...     summer.weekend.dusk = 1
         ...     level_names = ["semester", "week", "day"]
         ...     aggregates.allday = ["day", "night"]
-        ... \"\"\"
+        ... """
         >>> from muse.timeslices import (
         ...     reference_timeslice,  aggregate_transforms
         ... )
@@ -342,7 +342,7 @@ def timeslice_projector(
           - finest_week       (finest_timeslice) object 'weekday' ... 'weekend'
           - finest_day        (finest_timeslice) object 'day' 'night' ... 'night' 'dusk'
         Dimensions without coordinates: timeslice
-    """
+    '''
     from numpy import concatenate, ones_like
     from xarray import DataArray
 
@@ -402,7 +402,7 @@ def convert_timeslice(
     finest: Optional[DataArray] = None,
     transforms: Optional[Dict[Tuple, ndarray]] = None,
 ) -> Union[DataArray, Dataset]:
-    r"""Adjusts the timeslice of x to match that of ts.
+    '''Adjusts the timeslice of x to match that of ts.
 
     The conversion can be done in on of two ways, depending on whether the
     quantity is extensive or intensive. See `QuantityType`.
@@ -410,7 +410,7 @@ def convert_timeslice(
     Example:
         Lets define three timeslices from finest, to fine, to rough:
 
-        >>> toml = \"\"\"
+        >>> toml = """
         ...     ["timeslices"]
         ...     winter.weekday.day = 5
         ...     winter.weekday.night = 5
@@ -424,7 +424,7 @@ def convert_timeslice(
         ...     aggregates.allday = ["day", "night"]
         ...     aggregates.allweek = ["weekend", "weekday"]
         ...     aggregates.allyear = ["winter", "summer"]
-        ... \"\"\"
+        ... """
         >>> from muse.timeslices import setup_module
         >>> from muse.readers import read_timeslices
         >>> setup_module(toml)
@@ -526,7 +526,7 @@ def convert_timeslice(
         ... )
         >>> bool(all((weekend * 5).round(6) == (weekdays * 2).round(6)))
         True
-    """
+    '''
     if finest is None:
         global TIMESLICE
         finest = TIMESLICE

--- a/src/muse/utilities.py
+++ b/src/muse/utilities.py
@@ -317,7 +317,7 @@ def filter_with_template(
             format is that of an *asset* (see `broadcast_techs`)
         kwargs: passed on to `broadcast_techs` or `filter_input`
 
-    Returns
+    Returns:
         `data` transformed to match the form of `template`
     """
     if asset_dimension in template.dims:
@@ -433,7 +433,7 @@ def merge_assets(
 
 
 def avoid_repetitions(data: xr.DataArray, dim: Text = "year") -> xr.DataArray:
-    """list of years such that there is no repetition in the data.
+    """List of years such that there is no repetition in the data.
 
     It removes the central year of any three consecutive years where all data is
     the same. This means the original data can be reobtained via a linear
@@ -472,7 +472,6 @@ def future_propagation(
     """Propagates values into the future.
 
     Example:
-
         ``Data`` should be an array with at least one dimension, "year":
 
         >>> coords = dict(year=list(range(2020, 2040, 5)), fuel=["gas", "coal"])
@@ -550,7 +549,6 @@ def agent_concatenation(
     """Concatenates input map along given dimension.
 
     Example:
-
         Lets create sets of random assets to work with. We set the seed so that this
         test can be reproduced exactly.
 
@@ -629,7 +627,6 @@ def aggregate_technology_model(
     are grouped together and summed over.
 
     Example:
-
         We first create a random set of agent assets and aggregate them.
         Some of these agents own assets from the same technology but potentially with
         different installation year. This function will aggregate together all assets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,7 +207,7 @@ def coords() -> Mapping:
 
 @fixture
 def agent_args(coords) -> Mapping:
-    """some standard arguments defining an agent."""
+    """Some standard arguments defining an agent."""
     from numpy.random import choice, rand, randint
 
     return {
@@ -223,7 +223,7 @@ def agent_args(coords) -> Mapping:
 
 @fixture
 def technologies(coords) -> Dataset:
-    """randomly generated technology characteristics."""
+    """Randomly generated technology characteristics."""
     from muse.commodities import CommodityUsage
     from numpy import nonzero, sum
     from numpy.random import choice, rand, randint

--- a/tests/test_aggregoutput.py
+++ b/tests/test_aggregoutput.py
@@ -3,8 +3,10 @@ from muse.outputs.mca import sector_capacity
 
 
 def test_aggregate_sector():
-    """Test for aggregate_sector function check column titles, number of
-    agents/region/technologies and assets capacities."""
+    """Test for aggregate_sector function.
+
+    Check column titles, number of agents/region/technologies and assets capacities.
+    """
     from pandas import DataFrame, concat
 
     mca = examples.model("multiple_agents")
@@ -72,8 +74,10 @@ def test_aggregate_sectors():
 
 
 def test_aggregate_sector_manyregions():
-    """Test for aggregate_sector function with two regions check column titles, number
-    of agents/region/technologies and assets capacities."""
+    """Test for aggregate_sector function with two regions.
+
+    Check column titles, number of agents/region/technologies and assets capacities.
+    """
     from muse.outputs.mca import _aggregate_sectors
     from pandas import DataFrame, concat
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -127,7 +127,7 @@ def constraints(request, market_demand, assets, search_space, market, technologi
 
 
 def test_lp_constraints_matrix_b_is_scalar(constraint, lpcosts):
-    """b is a scalar.
+    """B is a scalar.
 
     When ``b`` is a scalar, the output should be equivalent to a single row matrix, or a
     single vector with only decision variables.
@@ -148,7 +148,7 @@ def test_lp_constraints_matrix_b_is_scalar(constraint, lpcosts):
 
 
 def test_max_production_constraint_diagonal(constraint, lpcosts):
-    """production side of max capacity production is diagonal.
+    """Production side of max capacity production is diagonal.
 
     The production for each timeslice, region, asset, and replacement technology should
     not outstrip the assigned for the asset and replacement technology. Hence, the

--- a/tests/test_legacy_sector.py
+++ b/tests/test_legacy_sector.py
@@ -59,7 +59,6 @@ def legacy_input_file(sector: Text) -> Optional[Path]:
 
 def update_settings(settings, sec_dir, out_dir):
     """Updates a settings namedtuple with temporal sectors and output directories."""
-
     sectors = settings.sectors
 
     for s in sectors.list:

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -8,7 +8,6 @@ from pytest import fixture, mark, raises
 @fixture
 def user_data_files(settings: dict) -> None:
     """Creates the files related to the user data."""
-
     files = list(settings["global_input_files"].keys())
     files.remove("path")
     for m in files:
@@ -40,7 +39,6 @@ def sectors_files(settings: dict):
 @fixture
 def plugins(settings: dict, tmp_path) -> Path:
     """Creates the files related to the custom modules."""
-
     plugin = tmp_path / "plugins" / "cat.py"
     plugin.parent.mkdir(parents=True, exist_ok=True)
     plugin.write_text("my_cat_colour = 'tabby' ")


### PR DESCRIPTION
Enables `ruff`'s pydocstyle checks and fix the errors. I've left warnings about missing
docstrings disabled, because adding all of them would be a rather large undertaking.

For missing argument descriptions I've done my best, but there was a bit of guesswork
involved in places.

Fixes #292.