### PR TITLE
VS Code: --no-cov argument no longer needed for pytest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,8 +17,6 @@
     "editor.formatOnSave": true,
     "editor.rulers": [88],
 
-    // --no-cov needed so that breakpoints work: https://github.com/microsoft/vscode-python/issues/693
-    "python.testing.pytestArgs": ["--no-cov"],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true
 }


### PR DESCRIPTION
The --no-cov argument is not only no longer necessary when invoking `pytest` from VS Code, but in this case, as we don't have `pytest-cov` installed, it means that the command will fail and VS Code will be unable to run the tests from the tests panel.

On another note, do we want to add `pytest-cov` to the dependencies? And on yet another note, do we want to install the codecov GitHub app so we can see coverage changes for PRs?