### PR TITLE
Improve documentation for `UtilizationFactor` parameter

### DIFF
--- a/docs/inputs/technodata.rst
+++ b/docs/inputs/technodata.rst
@@ -115,7 +115,7 @@ TechnicalLife
    represents the number of years that a technology operates before it is decommissioned.
 
 UtilizationFactor
-   represents the maximum actual output of the technology in a year, divided by the theoretical maximum output if the technology were operating at full capacity for the whole year.
+   represents the maximum actual output of the technology in a year, divided by the theoretical maximum output if the technology were operating at full capacity for the whole year. Should be between 0 and 1.
 
 ScalingSize
    represents the reference capacity at which capital costs are estimated when used as agents' objective as described in :ref:`inputs-agents`.

--- a/docs/inputs/technodata.rst
+++ b/docs/inputs/technodata.rst
@@ -115,7 +115,7 @@ TechnicalLife
    represents the number of years that a technology operates before it is decommissioned.
 
 UtilizationFactor
-   represents the maximum actual output of the technology in a year, divided by the theoretical maximum output if the technology were operating at full capacity for the whole year. Should be between 0 and 1.
+   represents the maximum actual output of the technology in a year, divided by the theoretical maximum output if the technology were operating at full capacity for the whole year. Must be between 0 and 1.
 
 ScalingSize
    represents the reference capacity at which capital costs are estimated when used as agents' objective as described in :ref:`inputs-agents`.

--- a/docs/inputs/technodata_timeslices.rst
+++ b/docs/inputs/technodata_timeslices.rst
@@ -34,7 +34,7 @@ hour
    represents the third level of the timeslice.
 
 UtilizationFactor
-   represents the maximum actual output of the technology in a timeslice, divided by the theoretical maximum output if the technology were operating at full capacity for the whole timeslice. Should be between 0 and 1. This overwrites the UtilizationFactor in the technodata file.
+   represents the maximum actual output of the technology in a timeslice, divided by the theoretical maximum output if the technology were operating at full capacity for the whole timeslice. Must be between 0 and 1. This overwrites the UtilizationFactor in the technodata file.
 
 MinimumServiceFactor
    represents the minimum service that a technology can output. For instance, the minimum amount of electricity that can be output from a nuclear power plant at a particular timeslice.

--- a/docs/inputs/technodata_timeslices.rst
+++ b/docs/inputs/technodata_timeslices.rst
@@ -34,7 +34,7 @@ hour
    represents the third level of the timeslice.
 
 UtilizationFactor
-   represents the maximum actual output of the technology in a year, divided by the theoretical maximum output if the technology were operating at full capacity for the whole year per timeslice. This overwrites the UtilizationFactor in the technodata file.
+   represents the maximum actual output of the technology in a timeslice, divided by the theoretical maximum output if the technology were operating at full capacity for the whole timeslice. Should be between 0 and 1. This overwrites the UtilizationFactor in the technodata file.
 
 MinimumServiceFactor
    represents the minimum service that a technology can output. For instance, the minimum amount of electricity that can be output from a nuclear power plant at a particular timeslice.


### PR DESCRIPTION
# Description

Improving the description for the `UtilizationFactor` parameter in the `TechnodataTimeslices` file, as suggested in #203. Also adding a note that Utilization factor should be between 0 and 1.

Fixes #203 

