### PR TITLE
Enforce minimum service factor limits

### DIFF
--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -1,6 +1,6 @@
 r"""Investment constraints.
 
-Constraints on investements ensure that investements match some given criteria. For
+Constraints on investments ensure that investments match some given criteria. For
 instance, the constraints could ensure that only so much of a new asset can be built
 every year.
 
@@ -8,7 +8,7 @@ Functions to compute constraints should be registered via the decorator
 :py:meth:`~muse.constraints.register_constraints`. This registration step makes it
 possible for constraints to be declared in the TOML file.
 
-Generally, LP solvers accept linear constraint defined as:
+Generally, LP solvers accept linear constraints defined as:
 
 .. math::
 
@@ -16,8 +16,8 @@ Generally, LP solvers accept linear constraint defined as:
 
 with :math:`A` a matrix, :math:`x` the decision variables, and :math:`b` a vector.
 However, these quantities are dimensionless. They do no have timeslices, assets, or
-replacement technologies, or any other dimensions that users have set-up in their model.
-The crux is to translates from MUSE's data-structures to a consistent dimensionless
+replacement technologies, or any other dimensions that users have set up in their model.
+The crux is to translate from MUSE's data-structures to a consistent dimensionless
 format.
 
 In MUSE, users can register constraints functions that return fully dimensional
@@ -44,8 +44,8 @@ happens as described below.
 - Any dimension in :math:`A_c .* x_c` (:math:`A_p .* x_p`) that is also in :math:`b`
   defines diagonal entries into the left (right) submatrix of :math:`A`.
 - Any dimension in :math:`A_c .* x_c` (:math:`A_p .* x_b`) and missing from
-  :math:`b` is reduce by summation over a row in the left (right) submatrix of
-  :math:`A`. In other words, those dimension do become part of a standard tensor
+  :math:`b` is reduced by summation over a row in the left (right) submatrix of
+  :math:`A`. In other words, those dimensions become part of a standard tensor
   reduction or matrix multiplication.
 
 There are two additional rules. However, they are likely to be the result of an
@@ -288,7 +288,7 @@ def max_capacity_expansion(
     :math:`y=y_1` is the year marking the end of the investment period.
 
     Let :math:`\mathcal{A}^{i, r}_{t, \iota}(y)` be the current assets, before
-    invesment, and let :math:`\Delta\mathcal{A}^{i,r}_t` be the future investements.
+    investment, and let :math:`\Delta\mathcal{A}^{i,r}_t` be the future investments.
     The the constraint on agent :math:`i` are given as:
 
     .. math::

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -519,13 +519,6 @@ def minimum_service(
         return None
     if np.all(technologies["minimum_service_factor"] == 0):
         return None
-
-    min_service_factor = technologies["minimum_service_factor"]
-    if not np.all((0 <= min_service_factor) & (min_service_factor <= 1)):
-        raise ValueError(
-            "Minimum service factor values must all be between 0 and 1 inclusive"
-        )
-
     if year is None:
         year = int(market.year.min())
     commodities = technologies.commodity.sel(

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -519,6 +519,13 @@ def minimum_service(
         return None
     if np.all(technologies["minimum_service_factor"] == 0):
         return None
+
+    min_service_factor = technologies["minimum_service_factor"]
+    if not np.all((0 <= min_service_factor) & (min_service_factor <= 1)):
+        raise ValueError(
+            "Minimum service factor values must all be between 0 and 1 inclusive"
+        )
+
     if year is None:
         year = int(market.year.min())
     commodities = technologies.commodity.sel(

--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -129,7 +129,7 @@ def read_technodata_timeslices(filename: Union[Text, Path]) -> xr.Dataset:
     data = csv[csv.technology != "Unit"]
 
     data = data.apply(lambda x: pd.to_numeric(x, errors="ignore"))
-    data = check_utilization_not_all_zero(data, filename)
+    check_utilization_not_all_zero(data, filename)
 
     ts = pd.MultiIndex.from_frame(
         data.drop(
@@ -921,4 +921,3 @@ def check_utilization_not_all_zero(data, filename):
             """A technology can not have a utilization factor of 0 for every
                 timeslice. Please check file {}.""".format(filename)
         )
-    return data

--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -114,6 +114,9 @@ def read_technodictionary(filename: Union[Text, Path]) -> xr.Dataset:
 
     if "year" in result.dims and len(result.year) == 1:
         result = result.isel(year=0, drop=True)
+
+    check_minimum_service_factors_in_range(data, filename)
+
     return result
 
 
@@ -920,4 +923,13 @@ def check_utilization_not_all_zero(data, filename):
         raise ValueError(
             """A technology can not have a utilization factor of 0 for every
                 timeslice. Please check file {}.""".format(filename)
+        )
+
+
+def check_minimum_service_factors_in_range(data, filename):
+    min_service_factor = data["minimum_service_factor"]
+    if not np.all((0 <= min_service_factor) & (min_service_factor <= 1)):
+        raise ValueError(
+            f"""Minimum service factor values must all be between 0 and 1 inclusive.
+             Please check file {filename}."""
         )

--- a/tests/test_minimum_service.py
+++ b/tests/test_minimum_service.py
@@ -1,9 +1,11 @@
+from itertools import permutations
+
 import numpy as np
 from pytest import mark
 
 
 def modify_minimum_service_factors(
-    model_path, sector, process_name, minimum_service_factor
+    model_path, sector, processes, minimum_service_factors
 ):
     import pandas as pd
 
@@ -11,28 +13,25 @@ def modify_minimum_service_factors(
         model_path / "technodata" / sector / "TechnodataTimeslices.csv"
     )
 
-    technodata_timeslices.loc[
-        technodata_timeslices["ProcessName"] == process_name[0], "MinimumServiceFactor"
-    ] = minimum_service_factor[0]
-
-    technodata_timeslices.loc[
-        technodata_timeslices["ProcessName"] == process_name[1], "MinimumServiceFactor"
-    ] = minimum_service_factor[1]
+    for process, minimum in zip(processes, minimum_service_factors):
+        technodata_timeslices.loc[
+            technodata_timeslices["ProcessName"] == process, "MinimumServiceFactor"
+        ] = minimum
 
     return technodata_timeslices
 
 
-@mark.parametrize("process_name", [("gasCCGT", "windturbine")])
 @mark.parametrize(
-    "minimum_service_factor",
-    [(np.linspace(0, 1, 6), [0] * 6), ([0], np.linspace(0, 1, 6))],
+    "minimum_service_factors",
+    permutations((np.linspace(0, 1, 6), [0] * 6)),
 )
-def test_minimum_service_factor(tmpdir, minimum_service_factor, process_name):
+def test_minimum_service_factor(tmpdir, minimum_service_factors):
     import pandas as pd
     from muse import examples
     from muse.mca import MCA
 
     sector = "power"
+    processes = ("gasCCGT", "windturbine")
 
     # Copy the model inputs to tmpdir
     model_path = examples.copy_model(
@@ -42,8 +41,8 @@ def test_minimum_service_factor(tmpdir, minimum_service_factor, process_name):
     technodata_timeslices = modify_minimum_service_factors(
         model_path=model_path,
         sector=sector,
-        process_name=process_name,
-        minimum_service_factor=minimum_service_factor,
+        processes=processes,
+        minimum_service_factors=minimum_service_factors,
     )
 
     technodata_timeslices.to_csv(
@@ -55,7 +54,7 @@ def test_minimum_service_factor(tmpdir, minimum_service_factor, process_name):
 
     supply_timeslice = pd.read_csv(tmpdir / "Results/MCAMetric_Supply.csv")
 
-    for process, service_factor in zip(process_name, minimum_service_factor):
+    for process, service_factor in zip(processes, minimum_service_factors):
         for i, factor in enumerate(service_factor):
             assert (
                 supply_timeslice[

--- a/tests/test_minimum_service.py
+++ b/tests/test_minimum_service.py
@@ -1,3 +1,4 @@
+import numpy as np
 from pytest import mark
 
 
@@ -23,7 +24,8 @@ def modify_minimum_service_factors(
 
 @mark.parametrize("process_name", [("gasCCGT", "windturbine")])
 @mark.parametrize(
-    "minimum_service_factor", [([1, 2, 3, 4, 5, 6], [0] * 6), ([0], [1, 2, 3, 4, 5, 6])]
+    "minimum_service_factor",
+    [(np.linspace(0, 1, 6), [0] * 6), ([0], np.linspace(0, 1, 6))],
 )
 def test_minimum_service_factor(tmpdir, minimum_service_factor, process_name):
     import pandas as pd


### PR DESCRIPTION
# Description

I've fixed #320 by introducing a check in the `minimum_service` constraint function that all minimum service factors are >=0 and <= 1 and I've also amended the spurious tests accordingly.

The only thing is that I'm wondering whether this is a bit late to raise an error. Should the check be in some earlier parsing step (either in addition or instead)?

While I was reading through the docstring for `muse.constraints` I noticed some typos and fixed those while I was at it.

Fixes #320.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
