### PR TITLE
Fix spelling: operative system => operating system

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ If applicable, add screenshots to help explain your problem.
 
 Please, complete the following to better understand the system you are using to run MUSE.
 
-- Operative system (eg. Windows 10):
+- Operating system (eg. Windows 10):
 - MUSE version (eg. 1.0.1):
 - Installation method (eg. pipx, pip, development mode):
 - Python version (you can get this running `python --version`):

--- a/.github/ISSUE_TEMPLATE/usage-support.md
+++ b/.github/ISSUE_TEMPLATE/usage-support.md
@@ -19,7 +19,7 @@ assignees: ''
 
 Please, complete the following to better understand the system you are using to run MUSE.
 
-- Operative system (eg. Windows 10):
+- Operating system (eg. Windows 10):
 - MUSE version (eg. 1.0.1):
 - Installation method (eg. pipx, pip, development mode):
 - Python version (you can get this running `python --version`):

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -1,7 +1,7 @@
 Installing MUSE
 ===============
 
-There are several ways of installing MUSE depending on your level of proficiency, your operative system and, specially, what you want to do with it (only using it or also developing it). In this section, you will find appropriate instructions for all of these use cases.
+There are several ways of installing MUSE depending on your level of proficiency, your operating system and, specially, what you want to do with it (only using it or also developing it). In this section, you will find appropriate instructions for all of these use cases.
 
 The following table summarises the different options to help you decide on the best one for you:
 
@@ -20,7 +20,7 @@ The following table summarises the different options to help you decide on the b
 +-----------------------------+--------------------------+------------------------+-------------------------+-----------------------+
 | **Access to source code**   | No                       | No                     | No                      | Yes                   |
 +-----------------------------+--------------------------+------------------------+-------------------------+-----------------------+
-| **Operative system**        | Windows only             | Win, Linux, MacOS      | Win, Linux, MacOS       | Win, Linux, MacOS     |
+| **Operating system**        | Windows only             | Win, Linux, MacOS      | Win, Linux, MacOS       | Win, Linux, MacOS     |
 +-----------------------------+--------------------------+------------------------+-------------------------+-----------------------+
 
 The :ref:`standalone-muse` and :ref:`pipx-based` installation methods should be the preferred ones for most users who just want to use MUSE *as is* or using custom plugins that only need dependencies already used by MUSE (eg. ``pandas``).

--- a/docs/installation/pipx-based.rst
+++ b/docs/installation/pipx-based.rst
@@ -35,7 +35,7 @@ In the following sections, we will guide you step by step in configuring your sy
 Launching a terminal
 ~~~~~~~~~~~~~~~~~~~~
 
-All operative systems have a Terminal application that let you run commands. You will need to use it extensively when using MUSE, so we strongly suggest you get familiar with it. For now, let's just figure out how to launch it:
+All operating systems have a Terminal application that let you run commands. You will need to use it extensively when using MUSE, so we strongly suggest you get familiar with it. For now, let's just figure out how to launch it:
 
 - **Linux**: Depending on the distribution, you might have a shortcut in your tasks bar already or it should be easily found in the menu. Look for ``Console`` or ``Terminal`` to lunch the application.
 - **MacOS**: Press ``Super key + Space`` to open the search box. There, type ``Terminal`` and press ``Enter``.
@@ -103,7 +103,7 @@ There are multiple ways of installing Python, as well as multiple distributions.
 Installing ``pyenv``
 ^^^^^^^^^^^^^^^^^^^^
 
-`pyenv <https://github.com/pyenv/pyenv>`_ (`pyenv-win <https://pyenv-win.github.io/pyenv-win/>`_ for Windows) is a tool that lets you install and manage different python versions. It is small, unobtrusive and self-contained, and it is available for the three operative systems. However, you might want to consider a more fully fledged Python distribution like Anaconda, specially if your work involved non-python packages or a lot of data science and machine learning tools. If that is the case, go to the :ref:`virtual-env-based` section.
+`pyenv <https://github.com/pyenv/pyenv>`_ (`pyenv-win <https://pyenv-win.github.io/pyenv-win/>`_ for Windows) is a tool that lets you install and manage different python versions. It is small, unobtrusive and self-contained, and it is available for the three operating systems. However, you might want to consider a more fully fledged Python distribution like Anaconda, specially if your work involved non-python packages or a lot of data science and machine learning tools. If that is the case, go to the :ref:`virtual-env-based` section.
 
 To install ``pyenv``, follow these steps:
 
@@ -199,7 +199,7 @@ Installing ``pipx``
 
 Next we need to install ``pipx``, a Python application manager that facilitates installing, keeping applications updated and run them in their own isolated environments. We could skip this step and install MUSE directly, but that will risk to have conflicting dependencies in the future if you install any other application, breaking your MUSE installation, and we do not want that to happen.
 
-The installation instructions for ``pipx`` can be found in the `official webpage <https://pypa.github.io/pipx/installation/>`_ specific for the three operative systems. The following instructions, however, should work for the three cases:
+The installation instructions for ``pipx`` can be found in the `official webpage <https://pypa.github.io/pipx/installation/>`_ specific for the three operating systems. The following instructions, however, should work for the three cases:
 
 .. code-block:: bash
 

--- a/docs/installation/virtual-env-based.rst
+++ b/docs/installation/virtual-env-based.rst
@@ -8,7 +8,7 @@ If the :ref:`pipx-based` does not work for you, you don't want to use ``pyenv`` 
 Installing Anaconda Python
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To install Anaconda, just go to the official `Anaconda webpage <https://www.anaconda.com/>`_ and download and install a version appropriate for your operative system. Do not worry about the Python version as ``conda`` will let you choose that when creating a virtual environment.
+To install Anaconda, just go to the official `Anaconda webpage <https://www.anaconda.com/>`_ and download and install a version appropriate for your operating system. Do not worry about the Python version as ``conda`` will let you choose that when creating a virtual environment.
 
 The installer should guide you step by step on the process of installing Anaconda and configuring your system to use it as your Python installation.
 
@@ -26,7 +26,7 @@ Using ``pipx`` ensures that each application it installs has its own virtual env
 Creating a ``conda`` virtual environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This option is available only if you installed Anaconda Python. Depending on the settings you used when installing Anaconda and your operative system, you might have ``conda`` available in your normal terminal or you might need to use the Anaconda Prompt.
+This option is available only if you installed Anaconda Python. Depending on the settings you used when installing Anaconda and your operating system, you might have ``conda`` available in your normal terminal or you might need to use the Anaconda Prompt.
 
 ``conda`` not only lets you create a virtual environment but also selecting which python version to use within, independently of the version of Anaconda Python installed, which means it can be an alternative to ``pyenv`` if it happens that you already have Anaconda installed in your system.
 


### PR DESCRIPTION
There are a bunch of places in the documentation where it says "operative system" instead of "operating system", which just sounds weird. Fix this.