### PR TITLE
Duckdb with sqlalchemy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ dependencies = [
     "pypubsub",
     "tomlkit",
     "duckdb",
-    "fsspec"
+    "fsspec",
+    "sqlalchemy",
+    "duckdb-engine"
 ]
 dynamic = ["version"]
 

--- a/src/muse/data/example/default_new_input/commodities.csv
+++ b/src/muse/data/example/default_new_input/commodities.csv
@@ -1,6 +1,6 @@
-commodity_name,description,type,unit
+name,description,type,unit
 electricity,Electricity,energy,PJ
 gas,Gas,energy,PJ
 heat,Heat,energy,PJ
 wind,Wind,energy,PJ
-C02f,Carbon dioxide,energy,kt
+CO2f,Carbon dioxide,energy,kt

--- a/src/muse/new_input/readers.py
+++ b/src/muse/new_input/readers.py
@@ -29,7 +29,9 @@ class Demand(TableBase):
 
     year: Mapped[int] = mapped_column(primary_key=True, autoincrement=False)
     commodity: Mapped[Commodities] = mapped_column(
-        ForeignKey("commodities.name"), primary_key=True
+        ForeignKey("commodities.name"),
+        primary_key=True,
+        info=dict(header="commodity_name"),
     )
     region: Mapped[Regions] = mapped_column(
         ForeignKey("regions.name"), primary_key=True
@@ -45,29 +47,29 @@ def read_inputs(data_dir):
     con = engine.raw_connection().driver_connection
 
     with open(data_dir / "regions.csv") as f:
-        regions = read_regions_csv(f, con)  # noqa: F841
+        regions = read_csv(f, Regions, con)  # noqa: F841
 
     with open(data_dir / "commodities.csv") as f:
-        commodities = read_commodities_csv(f, con)
+        commodities = read_csv(f, Commodities, con)
 
     with open(data_dir / "demand.csv") as f:
-        demand = read_demand_csv(f, con)  # noqa: F841
+        demand = read_csv(f, Demand, con)  # noqa: F841
 
     data = {}
     data["global_commodities"] = calculate_global_commodities(commodities)
     return data
 
 
-def read_regions_csv(buffer_, con):
-    rel = con.read_csv(buffer_, header=True, delimiter=",")  # noqa: F841
-    con.execute("INSERT INTO regions SELECT name FROM rel;")
-    return con.sql("SELECT name from regions").fetchnumpy()
+def read_csv(buffer_, table_class, con):
+    table_name = table_class.__tablename__
+    columns = ", ".join(
+        column.info.get("header", column.name)
+        for column in table_class.__table__.columns
+    )
 
-
-def read_commodities_csv(buffer_, con):
     rel = con.read_csv(buffer_, header=True, delimiter=",")  # noqa: F841
-    con.sql("INSERT INTO commodities SELECT name, type, unit FROM rel;")
-    return con.sql("select name, type, unit from commodities").fetchnumpy()
+    con.execute(f"INSERT INTO {table_name} SELECT {columns} FROM rel")
+    return con.execute(f"SELECT * from {table_name}").fetchnumpy()
 
 
 def calculate_global_commodities(commodities):
@@ -85,9 +87,3 @@ def calculate_global_commodities(commodities):
 
     data = xr.Dataset(data_vars=dict(type=type_array, unit=unit_array))
     return data
-
-
-def read_demand_csv(buffer_, con):
-    rel = con.read_csv(buffer_, header=True, delimiter=",")  # noqa: F841
-    con.sql("INSERT INTO demand SELECT year, commodity_name, region, demand FROM rel;")
-    return con.sql("SELECT * from demand").fetchnumpy()

--- a/src/muse/new_input/readers.py
+++ b/src/muse/new_input/readers.py
@@ -1,0 +1,76 @@
+import duckdb
+import numpy as np
+import xarray as xr
+
+
+def read_inputs(data_dir):
+    data = {}
+    con = duckdb.connect(":memory:")
+
+    with open(data_dir / "regions.csv") as f:
+        regions = read_regions_csv(f, con)  # noqa: F841
+
+    with open(data_dir / "commodities.csv") as f:
+        commodities = read_commodities_csv(f, con)
+
+    with open(data_dir / "demand.csv") as f:
+        demand = read_demand_csv(f, con)  # noqa: F841
+
+    data["global_commodities"] = calculate_global_commodities(commodities)
+    return data
+
+
+def read_regions_csv(buffer_, con):
+    sql = """CREATE TABLE regions (
+      name VARCHAR PRIMARY KEY,
+    );
+    """
+    con.sql(sql)
+    rel = con.read_csv(buffer_, header=True, delimiter=",")  # noqa: F841
+    con.sql("INSERT INTO regions SELECT name FROM rel;")
+    return con.sql("SELECT name from regions").fetchnumpy()
+
+
+def read_commodities_csv(buffer_, con):
+    sql = """CREATE TABLE commodities (
+      name VARCHAR PRIMARY KEY,
+      type VARCHAR CHECK (type IN ('energy', 'service', 'material', 'environmental')),
+      unit VARCHAR,
+    );
+    """
+    con.sql(sql)
+    rel = con.read_csv(buffer_, header=True, delimiter=",")  # noqa: F841
+    con.sql("INSERT INTO commodities SELECT name, type, unit FROM rel;")
+
+    return con.sql("select name, type, unit from commodities").fetchnumpy()
+
+
+def calculate_global_commodities(commodities):
+    names = commodities["name"].astype(np.dtype("str"))
+    types = commodities["type"].astype(np.dtype("str"))
+    units = commodities["unit"].astype(np.dtype("str"))
+
+    type_array = xr.DataArray(
+        data=types, dims=["commodity"], coords=dict(commodity=names)
+    )
+
+    unit_array = xr.DataArray(
+        data=units, dims=["commodity"], coords=dict(commodity=names)
+    )
+
+    data = xr.Dataset(data_vars=dict(type=type_array, unit=unit_array))
+    return data
+
+
+def read_demand_csv(buffer_, con):
+    sql = """CREATE TABLE demand (
+    year BIGINT,
+    commodity VARCHAR REFERENCES commodities(name),
+    region VARCHAR REFERENCES regions(name),
+    demand DOUBLE,
+    );
+    """
+    con.sql(sql)
+    rel = con.read_csv(buffer_, header=True, delimiter=",")  # noqa: F841
+    con.sql("INSERT INTO demand SELECT year, commodity_name, region, demand FROM rel;")
+    return con.sql("SELECT * from demand").fetchnumpy()

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -868,7 +868,14 @@ def default_new_input(tmp_path):
 
 @fixture
 def con():
-    return duckdb.connect(":memory:")
+    from muse.new_input.readers import TableBase
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    engine = create_engine("duckdb:///:memory:")
+    session = Session(engine)
+    TableBase.metadata.create_all(engine)
+    return session.connection().connection
 
 
 @fixture
@@ -899,7 +906,15 @@ def test_read_regions(populate_regions):
     assert populate_regions["name"] == np.array(["R1"])
 
 
-def test_read_new_global_commodities(populate_commodities):
+def test_read_regions_primary_key_constraint(default_new_input, con):
+    from muse.new_input.readers import read_regions_csv
+
+    csv = StringIO("name\nR1\nR1\n")
+    with raises(duckdb.ConstraintException, match=".*duplicate key.*"):
+        read_regions_csv(csv, con)
+
+
+def test_read_new_commodities(populate_commodities):
     data = populate_commodities
     assert list(data["name"]) == ["electricity", "gas", "heat", "wind", "CO2f"]
     assert list(data["type"]) == ["energy"] * 5
@@ -921,7 +936,15 @@ def test_calculate_global_commodities(populate_commodities):
     assert list(data.data_vars["unit"].values) == list(populate_commodities["unit"])
 
 
-def test_read_new_global_commodities_type_constraint(default_new_input, con):
+def test_read_new_commodities_primary_key_constraint(default_new_input, con):
+    from muse.new_input.readers import read_commodities_csv
+
+    csv = StringIO("name,type,unit\nfoo,energy,bar\nfoo,energy,bar\n")
+    with raises(duckdb.ConstraintException, match=".*duplicate key.*"):
+        read_commodities_csv(csv, con)
+
+
+def test_read_new_commodities_type_constraint(default_new_input, con):
     from muse.new_input.readers import read_commodities_csv
 
     csv = StringIO("name,type,unit\nfoo,invalid,bar\n")
@@ -954,6 +977,32 @@ def test_new_read_demand_csv_region_constraint(
 
     csv = StringIO("year,commodity_name,region,demand\n2020,heat,invalid,0\n")
     with raises(duckdb.ConstraintException, match=".*foreign key.*"):
+        read_demand_csv(csv, con)
+
+
+def test_new_read_demand_csv_primary_key_constraint(
+    default_new_input, con, populate_commodities, populate_regions
+):
+    from muse.new_input.readers import read_demand_csv, read_regions_csv
+
+    # Add another region so we can test varying it as a primary key
+    csv = StringIO("name\nR2\n")
+    read_regions_csv(csv, con)
+
+    # all fine so long as one primary key column differs
+    csv = StringIO(
+        """year,commodity_name,region,demand
+2020,gas,R1,0
+2021,gas,R1,0
+2020,heat,R1,0
+2020,gas,R2,0
+"""
+    )
+    read_demand_csv(csv, con)
+
+    # no good if all primary key columns match a previous entry
+    csv = StringIO("year,commodity_name,region,demand\n2020,gas,R1,0")
+    with raises(duckdb.ConstraintException, match=".*duplicate key.*"):
         read_demand_csv(csv, con)
 
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -880,26 +880,26 @@ def con():
 
 @fixture
 def populate_regions(default_new_input, con):
-    from muse.new_input.readers import read_regions_csv
+    from muse.new_input.readers import Regions, read_csv
 
     with open(default_new_input / "regions.csv") as f:
-        return read_regions_csv(f, con)
+        return read_csv(f, Regions, con)
 
 
 @fixture
 def populate_commodities(default_new_input, con):
-    from muse.new_input.readers import read_commodities_csv
+    from muse.new_input.readers import Commodities, read_csv
 
     with open(default_new_input / "commodities.csv") as f:
-        return read_commodities_csv(f, con)
+        return read_csv(f, Commodities, con)
 
 
 @fixture
 def populate_demand(default_new_input, con, populate_regions, populate_commodities):
-    from muse.new_input.readers import read_demand_csv
+    from muse.new_input.readers import Demand, read_csv
 
     with open(default_new_input / "demand.csv") as f:
-        return read_demand_csv(f, con)
+        return read_csv(f, Demand, con)
 
 
 def test_read_regions(populate_regions):
@@ -907,11 +907,11 @@ def test_read_regions(populate_regions):
 
 
 def test_read_regions_primary_key_constraint(default_new_input, con):
-    from muse.new_input.readers import read_regions_csv
+    from muse.new_input.readers import Regions, read_csv
 
     csv = StringIO("name\nR1\nR1\n")
     with raises(duckdb.ConstraintException, match=".*duplicate key.*"):
-        read_regions_csv(csv, con)
+        read_csv(csv, Regions, con)
 
 
 def test_read_new_commodities(populate_commodities):
@@ -937,19 +937,19 @@ def test_calculate_global_commodities(populate_commodities):
 
 
 def test_read_new_commodities_primary_key_constraint(default_new_input, con):
-    from muse.new_input.readers import read_commodities_csv
+    from muse.new_input.readers import Commodities, read_csv
 
     csv = StringIO("name,type,unit\nfoo,energy,bar\nfoo,energy,bar\n")
     with raises(duckdb.ConstraintException, match=".*duplicate key.*"):
-        read_commodities_csv(csv, con)
+        read_csv(csv, Commodities, con)
 
 
 def test_read_new_commodities_type_constraint(default_new_input, con):
-    from muse.new_input.readers import read_commodities_csv
+    from muse.new_input.readers import Commodities, read_csv
 
     csv = StringIO("name,type,unit\nfoo,invalid,bar\n")
     with raises(duckdb.ConstraintException):
-        read_commodities_csv(csv, con)
+        read_csv(csv, Commodities, con)
 
 
 def test_new_read_demand_csv(populate_demand):
@@ -963,31 +963,31 @@ def test_new_read_demand_csv(populate_demand):
 def test_new_read_demand_csv_commodity_constraint(
     default_new_input, con, populate_commodities, populate_regions
 ):
-    from muse.new_input.readers import read_demand_csv
+    from muse.new_input.readers import Demand, read_csv
 
     csv = StringIO("year,commodity_name,region,demand\n2020,invalid,R1,0\n")
     with raises(duckdb.ConstraintException, match=".*foreign key.*"):
-        read_demand_csv(csv, con)
+        read_csv(csv, Demand, con)
 
 
 def test_new_read_demand_csv_region_constraint(
     default_new_input, con, populate_commodities, populate_regions
 ):
-    from muse.new_input.readers import read_demand_csv
+    from muse.new_input.readers import Demand, read_csv
 
     csv = StringIO("year,commodity_name,region,demand\n2020,heat,invalid,0\n")
     with raises(duckdb.ConstraintException, match=".*foreign key.*"):
-        read_demand_csv(csv, con)
+        read_csv(csv, Demand, con)
 
 
 def test_new_read_demand_csv_primary_key_constraint(
     default_new_input, con, populate_commodities, populate_regions
 ):
-    from muse.new_input.readers import read_demand_csv, read_regions_csv
+    from muse.new_input.readers import Demand, Regions, read_csv
 
     # Add another region so we can test varying it as a primary key
     csv = StringIO("name\nR2\n")
-    read_regions_csv(csv, con)
+    read_csv(csv, Regions, con)
 
     # all fine so long as one primary key column differs
     csv = StringIO(
@@ -998,12 +998,12 @@ def test_new_read_demand_csv_primary_key_constraint(
 2020,gas,R2,0
 """
     )
-    read_demand_csv(csv, con)
+    read_csv(csv, Demand, con)
 
     # no good if all primary key columns match a previous entry
     csv = StringIO("year,commodity_name,region,demand\n2020,gas,R1,0")
     with raises(duckdb.ConstraintException, match=".*duplicate key.*"):
-        read_demand_csv(csv, con)
+        read_csv(csv, Demand, con)
 
 
 @mark.xfail


### PR DESCRIPTION
# Description

This PR builds on #379 prototypes a partial adoption of SQLAlchemy in combination with Duckdb. This attempts to get the best of both worlds by using SQLAlchemy to define the database schema whilst still leveraging the capabilities of Duckdb to work with CSV files and easily spit out numpy arrays.

The main point in using SQLAlchemy here is to cut down on the amount of SQL that needs to be written and to do schema definition via the Python declarative interface. By having a generic CSV reader function you can then cut down to two simple lines of SQL. The advantage of this may be more apparent in a more mature implementation that will require more complex SQL in the duckdb only approach.

One very nice side benefit of having the schema in SQLAlchemy would be on the input creation side. At the moment the only real approach is to hack a bunch of csv files and deal with errors as you try to read them in. Instead you could use the SQLAlchemy classes to populate a database then dump it into csv files which could be quite powerful in the case of large or complex input datasets.

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/EnergySystemsModellingLab/MUSE_OS/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
