### PR TITLE
Correctly use the minimum service factor

### DIFF
--- a/docs/inputs/technodata.rst
+++ b/docs/inputs/technodata.rst
@@ -112,7 +112,10 @@ TechnicalLife
    represents the number of years that a technology operates before it is decommissioned.
 
 UtilizationFactor
-   represents the maximum actual output of the technology in a year, divided by the theoretical maximum output if the technology were operating at full capacity for the whole year. Must be between 0 and 1.
+   represents the *maximum* actual output of the technology in a year, divided by the theoretical maximum output if the technology were operating at full capacity for the whole year. Must be between 0 and 1.
+
+MinimumServiceFactor
+   Is the *minimum* output of the technology in a year, divided by the theoretical maximum output if the technology were operating at full capacity for the whole year. Must be between 0 and 1 and be smaller or equal than the `UtilizationFactor`. It is used to define the minimum service level that a technology must provide due to, typically, technical or efficiency constraints.
 
 ScalingSize
    represents the reference capacity at which capital costs are estimated when used as agents' objective as described in :ref:`inputs-agents`.

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -530,7 +530,7 @@ def minimum_service(
         .drop_vars("technology")
     )
     capacity = convert_timeslice(
-        techs.fixed_outputs * techs.utilization_factor * techs.minimum_service_factor,
+        techs.fixed_outputs * techs.minimum_service_factor,
         market.timeslice,
         QuantityType.EXTENSIVE,
     )


### PR DESCRIPTION
# Description

As ti was being used as a fraction of the utilisation factor rather as a fraction of 100%.

Fixes #375 

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/EnergySystemsModellingLab/MUSE_OS/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass: `$ python -m pytest`
- [x] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
