### PR TITLE
Remove other references to SGI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,6 @@ authors:
     - family-names: Hawkes
       given-names: Adam
 
-title: SGIModel/MUSE_OS
+title: MUSE_OS
 version: v1.0.1
 date-released: 2022-03-25

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "MUSE"
-copyright = "2022, Sustainable Gas Institute"
+copyright = "2024, Imperial College London"
 author = "Imperial College London"
 release = "1.1.0"
 version = ".".join(release.split(".")[:2])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ excel = ["openpyxl"]
 gui = ["gooey"]
 
 [project.urls]
-Homepage = "http://www.sustainablegasinstitute.org/home/muse-energy-model/"
+Homepage = "https://www.imperial.ac.uk/muse-energy/what-is-muse-/"
 
 [project.scripts]
 muse = "muse.__main__:run"


### PR DESCRIPTION
I noticed that there's still a reference to SGI in the copyright notice (you can see it in the footer of the documentation). I've updated the copyright owner to be "Imperial College London" and I changed the year while I was at it.

There was also a reference to SGI in `CITATION.cff` -- I think it refers to the old GitHub org, but I don't think that's needed: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files

FYI @ahawkes 