### PR TITLE
Quick fix for float-integer error

### DIFF
--- a/src/muse/timeslices.py
+++ b/src/muse/timeslices.py
@@ -549,7 +549,7 @@ def convert_timeslice(
         index = index.set_names(f"finest_{u}" for u in index.names)
         mindex_coords = xr.Coordinates.from_pandas_multiindex(index, "finest_timeslice")
         finest = finest.drop_vars(list(finest.coords)).assign_coords(mindex_coords)
-        proj0 *= finest
+        proj0 = proj0*finest
         proj0 = proj0 / proj0.sum("finest_timeslice")
     elif quantity is QuantityType.INTENSIVE:
         proj1 = proj1 / proj1.sum("finest_timeslice")


### PR DESCRIPTION
# Description

There is an instance of the *= operation in timeslices.py where the variables are not necessarily the same type. This sometimes causes the error describes in #408.

Fixes #408

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/EnergySystemsModellingLab/MUSE_OS/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
