### PR TITLE
Pin bottleneck dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "scipy>=1.13",
     "pandas>=2.2",
     "xarray>=2024.6",
-    "bottleneck",
+    "bottleneck>=1.4",
     "coloredlogs",
     "toml",
     "xlrd",


### PR DESCRIPTION
Tried to upgrade Sharwari's environment for the new MUSE version and had some problems. Turns out `bottleneck` also needs to be pinned
