### PR TITLE
Update documentation for `demand_share` parameter

### DIFF
--- a/docs/inputs/toml.rst
+++ b/docs/inputs/toml.rst
@@ -522,13 +522,13 @@ to define the timeslice simply by referring to the slices it will use at each le
         in the simulation. There are currently two options:
 
         - :py:func:`~muse.demand_share.standard_demand` (default): The input demand is
-        split amongst *new* agents. *New* agents get a share of the increase in demand
-        for the forecast years, as well as the demand that occurs from decommissioned
-        assets.
+          split amongst *new* agents. *New* agents get a share of the increase in demand
+          for the forecast years, as well as the demand that occurs from decommissioned
+          assets.
         - :py:func:`~muse.demand_share.new_and_retro`: The input demand is split amongst
-        both *new* and *retrofit* agents. *New* agents get a share of the increase in
-        demand for the forecast year, whereas *retrofit* agents are assigned a share of
-        the demand that occurs from decommissioned assets.
+          both *new* and *retrofit* agents. *New* agents get a share of the increase in
+          demand for the forecast year, whereas *retrofit* agents are assigned a share
+          of the demand that occurs from decommissioned assets.
 
     *constraints*
         The list of constraints to apply to the LP problem solved by the sector. By

--- a/docs/inputs/toml.rst
+++ b/docs/inputs/toml.rst
@@ -518,18 +518,17 @@ to define the timeslice simply by referring to the slices it will use at each le
 
     *demand_share*
         A method used to split the MCA demand into separate parts to be serviced by
-        specific agents. A basic distinction is between *new* and *retrofit* agents: the
-        former asked to respond to an increase of commodity demand investing in new
-        assets; the latter asked to invest in new asset to balance the decommissined
+        specific agents. The appropriate choice depends on the type of agents being used
+        in the simulation. There are currently two options:
+
+        - :py:func:`~muse.demand_share.standard_demand` (default): The input demand is
+        split amongst *new* agents. *New* agents get a share of the increase in demand
+        for the forecast years, as well as the demand that occurs from decommissioned
         assets.
-
-        There are currently two options:
-
-        - :py:func:`~muse.demand_share.new_and_retro`: the demand is split into a
-          retrofit demand corresponding to demand that used to be serviced by
-          decommisioned assets, and the *new* demand.
-        - :py:func:`~muse.demand_share.market_demand`: simply the consumption for the
-          forecast year.
+        - :py:func:`~muse.demand_share.new_and_retro`: The input demand is split amongst
+        both *new* and *retrofit* agents. *New* agents get a share of the increase in
+        demand for the forecast year, whereas *retrofit* agents are assigned a share of
+        the demand that occurs from decommissioned assets.
 
     *constraints*
         The list of constraints to apply to the LP problem solved by the sector. By

--- a/src/muse/data/example/trade/technodata/Agents.csv
+++ b/src/muse/data/example/trade/technodata/Agents.csv
@@ -1,3 +1,3 @@
 AgentShare,Name,RegionName,Objective,ObjData,Objsort,SearchRule,DecisionMethod,MaturityThreshold,SpendLimit,Type
-agent_share,A1,R1,ALCOE,1,TRUE,from_assets->compress->reduce_assets,singleObj,-1,inf,default
-agent_share,A1,R2,ALCOE,1,TRUE,from_assets->compress->reduce_assets,singleObj,-1,inf,default
+agent_share,A1,R1,ALCOE,1,TRUE,from_assets->compress->reduce_assets,singleObj,-1,inf,Retrofit
+agent_share,A1,R2,ALCOE,1,TRUE,from_assets->compress->reduce_assets,singleObj,-1,inf,Retrofit

--- a/src/muse/data/example/trade/technodata/Agents.csv
+++ b/src/muse/data/example/trade/technodata/Agents.csv
@@ -1,3 +1,3 @@
 AgentShare,Name,RegionName,Objective,ObjData,Objsort,SearchRule,DecisionMethod,MaturityThreshold,SpendLimit,Type
-agent_share,A1,R1,ALCOE,1,TRUE,from_assets->compress->reduce_assets,singleObj,-1,inf,Retrofit
-agent_share,A1,R2,ALCOE,1,TRUE,from_assets->compress->reduce_assets,singleObj,-1,inf,Retrofit
+agent_share,A1,R1,ALCOE,1,TRUE,from_assets->compress->reduce_assets,singleObj,-1,inf,default
+agent_share,A1,R2,ALCOE,1,TRUE,from_assets->compress->reduce_assets,singleObj,-1,inf,default

--- a/src/muse/demand_share.py
+++ b/src/muse/demand_share.py
@@ -107,7 +107,7 @@ def factory(
     return cast(DEMAND_SHARE_SIGNATURE, demand_share)
 
 
-@register_demand_share(name="default")
+@register_demand_share(name="new_and_retro")
 def new_and_retro(
     agents: Sequence[AbstractAgent],
     market: xr.Dataset,
@@ -118,9 +118,9 @@ def new_and_retro(
 ) -> xr.DataArray:
     r"""Splits demand across new and retro agents.
 
-    The input demand is split amongst both *new* and *retro* agents. *New* agents get a
-    share of the increase in demand for the forecast year, whereas *retrofi* agents are
-    assigned a share of the demand that occurs from decommissioned assets.
+    The input demand is split amongst both *new* and *retrofit* agents. *New* agents get
+    a share of the increase in demand for the forecast year, whereas *retrofit* agents
+    are assigned a share of the demand that occurs from decommissioned assets.
 
     Args:
         agents: a list of all agents. This list should mainly be used to determine the
@@ -318,7 +318,7 @@ def new_and_retro(
     return result
 
 
-@register_demand_share(name="standard_demand")
+@register_demand_share(name="default")
 def standard_demand(
     agents: Sequence[AbstractAgent],
     market: xr.Dataset,
@@ -330,7 +330,7 @@ def standard_demand(
     r"""Splits demand across new agents.
 
     The input demand is split amongst *new* agents. *New* agents get a
-    share of the increase in demand for the forecast years well as the demand that
+    share of the increase in demand for the forecast years, as well as the demand that
     occurs from decommissioned assets.
 
     Args:


### PR DESCRIPTION
# Description

The options have changed since the documentation was last updated, as well as the default value.

Also, whilst #349 changed the default value to "standard_demand" in the sense that if `demand_share` isn't specified in the settings file it will default to this value, if you wrote `demand_share = "default"` it would still default to "new_and_retro". So I've fixed that.

Close #341 