### PR TITLE
Fix: Upload test coverage for push events only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
               --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: success() && (runner.os == 'Linux' && matrix.python-version == 3.9)
+        if: success() && (github.event_name == 'push' && runner.os == 'Linux' && matrix.python-version == 3.9)
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
The problem is that for some reason the `CODECOV_TOKEN` GitHub secret is not available for workflows running in response to `release` events. That said, we only actually need the test coverage to be uploaded for `push` events anyway, so we can fix this by adding a conditional.

I tested this conditional by making a separate workflow that only runs in response to `push` events.

I've made this PR against `main` rather than `develop`, so we'll have to do another merge after this.

Unfortunately to fix the release I think we're going to have to delete it along with the git tag and recreate it :disappointed: 

Fixes #440.