### PR TITLE
Only run release workflow once

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publishing
 
-on: [release]
+on:
+  release:
+    types: [published]
 
 jobs:
   test:


### PR DESCRIPTION
I am reliably informed by @AdrianDAlessandro that if you just specify `on: [release]` for a workflow, it will run multiple times when you create a new release. Indeed it seems that it has been running three times every time I make a new release (and I've been doing that a lot in a desperate bid to fix #443...).