### PR TITLE
Rename threshhold to threshold

### DIFF
--- a/src/muse/agents/agent.py
+++ b/src/muse/agents/agent.py
@@ -113,13 +113,13 @@ class Agent(AbstractAgent):
         objectives: Optional[Callable] = None,
         decision: Optional[Callable] = None,
         year: int = 2010,
-        maturity_threshhold: float = 0,
+        maturity_threshold: float = 0,
         forecast: int = 5,
         housekeeping: Optional[Callable] = None,
         merge_transform: Optional[Callable] = None,
-        demand_threshhold: Optional[float] = None,
+        demand_threshold: Optional[float] = None,
         category: Optional[str] = None,
-        asset_threshhold: float = 1e-4,
+        asset_threshold: float = 1e-4,
         quantity: Optional[float] = 1,
         spend_limit: int = 0,
         **kwargs,
@@ -136,17 +136,17 @@ class Agent(AbstractAgent):
             objectives: One or more objectives by which to decide next investments.
             decision: single decision objective from one or more objectives.
             year: year the agent is created / current year
-            maturity_threshhold: threshold when filtering replacement
+            maturity_threshold: threshold when filtering replacement
                 technologies with respect to market share
             forecast: Number of years the agent will forecast
             housekeeping: transform applied to the assets at the start of
                 iteration. Defaults to doing nothing.
             merge_transform: transform merging current and newly invested assets
                 together. Defaults to replacing old assets completely.
-            demand_threshhold: criteria below which the demand is zero.
+            demand_threshold: criteria below which the demand is zero.
             category: optional attribute that could be used to classify
                 different agents together.
-            asset_threshhold: Threshold below which assets are not added.
+            asset_threshold: Threshold below which assets are not added.
             quantity: different agents' share of the population
             spend_limit: The cost above which agents will not invest
             **kwargs: Extra arguments
@@ -182,7 +182,7 @@ class Agent(AbstractAgent):
         function registered via `muse.filters.register_filter` can be
         used to filter the search space.
         """
-        self.maturity_threshhold = maturity_threshhold
+        self.maturity_threshold = maturity_threshold
         """ Market share threshold.
 
         Threshold when and if filtering replacement technologies with respect
@@ -217,13 +217,13 @@ class Agent(AbstractAgent):
         It can be any function registered with
         :py:func:`~muse.hooks.register_final_asset_transform`.
         """
-        self.demand_threshhold = demand_threshhold
+        self.demand_threshold = demand_threshold
         """Threshold below which the demand share is zero.
 
         This criteria avoids fulfilling demand for very small values. If None,
         then the criteria is not applied.
         """
-        self.asset_threshhold = asset_threshhold
+        self.asset_threshold = asset_threshold
         """Threshold below which assets are not added."""
 
     @property
@@ -331,7 +331,7 @@ class Agent(AbstractAgent):
         if "agent" in investments.dims:
             investments = investments.squeeze("agent", drop=True)
         investments = investments.sel(
-            replacement=(investments > self.asset_threshhold).any(
+            replacement=(investments > self.asset_threshold).any(
                 [d for d in investments.dims if d != "replacement"]
             )
         )

--- a/src/muse/data/example/trade/settings.toml
+++ b/src/muse/data/example/trade/settings.toml
@@ -60,7 +60,7 @@ constraints = [
 ]
 demand_share = "new_and_retro"
 forecast = 5
-asset_threshhold = 1e-4
+asset_threshold = 1e-4
 
 [[sectors.residential.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
@@ -99,7 +99,7 @@ constraints = [
 ]
 demand_share = "unmet_forecasted_demand"
 forecast = 5
-asset_threshhold = 1e-4
+asset_threshold = 1e-4
 
 [[sectors.power.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'
@@ -142,7 +142,7 @@ constraints = [
 ]
 demand_share = "unmet_forecasted_demand"
 forecast = 5
-asset_threshhold = 1e-4
+asset_threshold = 1e-4
 
 [[sectors.gas.outputs]]
 filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}/{year}{suffix}'

--- a/src/muse/filters.py
+++ b/src/muse/filters.py
@@ -341,7 +341,7 @@ def maturity(
     """
     capacity = agent.filter_input(market.capacity, year=agent.year)
     total_capacity = capacity.sum("technology")
-    enduse_market_share = agent.maturity_threshhold * total_capacity
+    enduse_market_share = agent.maturity_threshold * total_capacity
     condition = enduse_market_share <= capacity
     techs = (
         condition.technology.where(condition, drop=True).drop_vars("technology").values

--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -593,7 +593,7 @@ def read_csv_agent_parameters(filename) -> list:
         if hasattr(row, "Quantity"):
             data["quantity"] = row.Quantity
         if hasattr(row, "MaturityThreshold"):
-            data["maturity_threshhold"] = row.MaturityThreshold
+            data["maturity_threshold"] = row.MaturityThreshold
         if hasattr(row, "SpendLimit"):
             data["spend_limit"] = row.SpendLimit
         # if agent_type != "newcapa":

--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -175,6 +175,11 @@ class Subsector:
         from muse.commodities import is_enduse
         from muse.readers.toml import undo_damage
 
+        # Raise error for renamed asset_threshhold parameter (PR #447)
+        if hasattr(settings, "asset_threshhold"):
+            msg = "Invalid parameter asset_threshhold. Did you mean asset_threshold?"
+            raise ValueError(msg)
+
         agents = agents_factory(
             settings.agents,
             settings.existing_capacity,

--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -181,7 +181,7 @@ class Subsector:
             technologies=technologies,
             regions=regions,
             year=current_year or int(technologies.year.min()),
-            asset_threshhold=getattr(settings, "asset_threshhold", 1e-12),
+            asset_threshold=getattr(settings, "asset_threshold", 1e-12),
             # only used by self-investing agents
             investment=getattr(settings, "lpsolver", "adhoc"),
             forecast=getattr(settings, "forecast", 5),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,7 +231,7 @@ def agent_args(coords) -> Mapping:
             "space_heating": randint(0, 1000),
             "water_heating": randint(0, 1000),
         },
-        "maturity_threshhold": rand(),
+        "maturity_threshold": rand(),
     }
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -162,20 +162,20 @@ def test_maturity(retro_agent, search_space, technologies, agent_market):
     production = (outputs * capacity).sum("technology")
 
     # nothing should be true
-    retro_agent.maturity_threshhold = 1.1 * (capacity / production).max()
+    retro_agent.maturity_threshold = 1.1 * (capacity / production).max()
     actual = maturity(retro_agent, search_space, technologies, agent_market)
     assert sorted(actual.dims) == sorted(search_space.dims)
     assert (not actual).all()
 
     # some should be true - do it with a fully on search space for  simplicity
-    retro_agent.maturity_threshhold = 0.8 * (capacity / production).max()
+    retro_agent.maturity_threshold = 0.8 * (capacity / production).max()
     actual = maturity(
         search_space == retro_agent, search_space, technologies, agent_market
     )
     assert sorted(actual.dims) == sorted(search_space.dims)
     assert actual.any()
     # all should be true
-    retro_agent.maturity_threshhold = 0.8 * (capacity / production).min()
+    retro_agent.maturity_threshold = 0.8 * (capacity / production).min()
     actual = maturity(retro_agent, search_space, technologies, agent_market)
     assert (actual == search_space).any()
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -591,7 +591,7 @@ def test_read_csv_agent_parameters(default_model):
             "decision": {"name": "singleObj", "parameters": [("LCOE", True, 1)]},
             "agent_type": "newcapa",
             "quantity": 1,
-            "maturity_threshhold": -1,
+            "maturity_threshold": -1,
             "spend_limit": np.inf,
             "share": "agent_share_1",
         },


### PR DESCRIPTION
# Description

Renames the incorrect spelling "threshhold" in three parameters. I've also added a warning if a user attempts to use "asset_threshhold" in the settings file. This isn't required for the other two parameters, see [here](https://github.com/EnergySystemsModellingLab/MUSE_OS/issues/301#issuecomment-2273806394)

Apparently none of these parameters are explained in the documentation, so there's nothing that needs changing in the documentation, but this obviously isn't a good thing!

Fixes #301

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/EnergySystemsModellingLab/MUSE_OS/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
