### PR TITLE
Fix bugs in the carbon budget bisection algorithm

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0rc4
+current_version = 1.2.1rc1
 commit = True
 tag = True
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,5 +9,5 @@ authors:
       given-names: Adam
 
 title: MUSE_OS
-version: v1.2.0rc4
+version: v1.2.1rc1
 date-released: 2024-08-13

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@
 project = "MUSE"
 copyright = "2024, Imperial College London"
 author = "Imperial College London"
-release = "1.2.0rc4"
+release = "1.2.1rc1"
 version = ".".join(release.split(".")[:2])
 
 # -- General configuration ---------------------------------------------------

--- a/src/muse/__init__.py
+++ b/src/muse/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 
-VERSION = "1.2.0rc4"
+VERSION = "1.2.1rc1"
 
 
 def _create_logger(color: bool = True):

--- a/src/muse/carbon_budget.py
+++ b/src/muse/carbon_budget.py
@@ -527,7 +527,7 @@ def min_max_bisect(
 
     if ub > threshold and lb < threshold:
         # Threshold is between bounds -> perform bisection
-        midpoint = (low + up) / 2.0
+        midpoint = round((low + up) / 2.0, 2)
         m = bisect_loop(market, sectors, equilibrium, commodities, midpoint)
         emissions_cache[midpoint] = m
         if m < threshold:
@@ -540,7 +540,7 @@ def min_max_bisect(
     # Inverted bounds (i.e. increasing price leads to increasing emissions)
     # Unlikely case, but included for completeness
     if ub < threshold and lb > threshold:
-        midpoint = (low + up) / 2.0
+        midpoint = round((low + up) / 2.0, 2)
         m = bisect_loop(market, sectors, equilibrium, commodities, midpoint)
         emissions_cache[midpoint] = m
         if m > threshold:

--- a/src/muse/carbon_budget.py
+++ b/src/muse/carbon_budget.py
@@ -375,6 +375,7 @@ def bisection(
     price_too_high_threshold: float = 10,
     tolerance: float = 0.1,
     early_termination_count: int = 5,
+    **kwargs,
 ) -> float:
     """Applies bisection algorithm to escalate carbon price and meet the budget.
 
@@ -399,46 +400,41 @@ def bisection(
         tolerance: Maximum permitted deviation of emissions from the budget
         early_termination_count: Will terminate the loop early if the last n solutions
             are the same
+        kwargs: Additional arguments (unused)
 
     Returns:
         New value of global carbon price
     """
     from logging import getLogger
 
-    # We calculate the carbon price and emissions threshold in the forecast year
+    # Carbon price and emissions threshold in the forecast year
     future = market.year[-1]
-    threshold = carbon_budget.sel(year=future).values.item()
+    target = carbon_budget.sel(year=future).values.item()
     price = market.prices.sel(year=future, commodity=commodities).mean().values.item()
 
     # Initial lower and upper bounds on carbon price for the bisection algorithm
     current = market.year[0]
     time_exp = int(future - current)
-    low = 0.01
-    up = max(price, 0.01) * 1.1**time_exp  # i.e. 10% yearly increase on current price
+    lb_price = 0.01
+    ub_price = (
+        max(price, 0.01) * 1.1**time_exp
+    )  # i.e. 10% yearly increase on current price
 
     # Bisection loop
-    emissions_cache: dict[float, float] = {}  # caches emissions for different prices
+    emissions_cache = EmissionsCache(market, equilibrium, commodities)
     for _ in range(sample_size):  # maximum number of iterations before terminating
         # Cap prices between 0.01 and price_too_high_threshold
         if refine_price:
-            up = min(up, price_too_high_threshold)
-        low = max(low, 0.01)
+            ub_price = min(ub_price, price_too_high_threshold)
+        lb_price = max(lb_price, 0.01)
 
         # Round prices to 2dp
-        low = round(low, 2)
-        up = round(up, 2)
+        lb_price = round(lb_price, 2)
+        ub_price = round(ub_price, 2)
 
-        # Calculate carbon emissions at new bounds
-        if low not in emissions_cache:
-            emissions_cache[low] = bisect_loop(
-                market, sectors, equilibrium, commodities, low
-            )
-        ub = emissions_cache[low]
-        if up not in emissions_cache:
-            emissions_cache[up] = bisect_loop(
-                market, sectors, equilibrium, commodities, up
-            )
-        lb = emissions_cache[up]
+        # Calculate/retrieve carbon emissions at new bounds
+        lb_price_emissions = emissions_cache[lb_price]
+        ub_price_emissions = emissions_cache[ub_price]
 
         # Terminate early if many consecutive emissions are the same
         if len(emissions_cache) >= early_termination_count + 2:
@@ -447,23 +443,17 @@ def bisection(
                 break
 
         # Exit loop if lower or upper bound on emissions is close to threshold
-        if abs(ub - threshold) <= abs(tolerance * threshold):
-            return low
-        if abs(lb - threshold) <= abs(tolerance * threshold):
-            return up
+        if abs(lb_price_emissions - target) <= abs(tolerance * target):
+            return lb_price
+        if abs(ub_price_emissions - target) <= abs(tolerance * target):
+            return ub_price
 
         # Convergence not yet reached -> calculate new bounds
-        low, up = min_max_bisect(
-            low,
-            lb,
-            up,
-            ub,
-            market,
-            sectors,
-            equilibrium,
-            commodities,
-            threshold,  # type: ignore
-            emissions_cache=emissions_cache,
+        lb_price, ub_price = adjust_bounds(
+            lb_price,
+            ub_price,
+            emissions_cache,
+            target,
         )
 
     # If convergence isn't reached, new price is that with emissions closest to
@@ -473,93 +463,145 @@ def bisection(
         "Try increasing the tolerance or sample size."
     )
     getLogger(__name__).warning(message)
-    return min(emissions_cache, key=lambda k: (abs(emissions_cache[k] - threshold), k))
+    return min(emissions_cache, key=lambda k: (abs(emissions_cache[k] - target), k))
 
 
-def min_max_bisect(
-    low: float,
-    lb: float,
-    up: float,
-    ub: float,
-    market: xr.Dataset,
-    sectors: list,
-    equilibrium: Callable[
-        [xr.Dataset, Sequence[AbstractSector], int], FindEquilibriumResults
-    ],
-    commodities: list,
-    threshold: float,
-    emissions_cache: dict[float, float] = {},
-):
-    """Refines bisection algorithm to escalate carbon price and meet the budget.
+class EmissionsCache(dict):
+    """Cache of emissions at different price points for bisection algorithm.
+
+    If a price is queried that is not in the cache, it calculates the emissions at that
+    price using bisect_solve_market and stores the result in the cache.
+    """
+
+    def __init__(self, market, equilibrium, commodities):
+        super().__init__()
+        self.market = market
+        self.equilibrium = equilibrium
+        self.commodities = commodities
+
+    def __missing__(self, price):
+        value = bisect_solve_market(
+            self.market, self.equilibrium, self.commodities, price
+        )
+        self[price] = value
+        return value
+
+
+def adjust_bounds(
+    lb_price: float,
+    ub_price: float,
+    emissions_cache: dict[float, float],
+    target: float,
+) -> tuple[float, float]:
+    """Adjust the bounds of the carbon price for the bisection algorithm.
 
     As emissions can be a discontinuous function of the carbon price, this method is
     used to improve the solution search when discontinuities are met, improving the
     bounds search.
 
     Arguments:
-        low: Value of carbon price at lower bound
-        lb: Value of emissions at lower bound
-        up: Value of carbon price at upper bound
-        ub: Value of emissions at upper bound
-        market: Market, with the prices, supply, consumption and demand
-        sectors: List of sectors
-        equilibrium: Method for searching market equilibrium
-        commodities: List of carbon-related commodities
-        threshold: Carbon budget
-        emissions_cache: Cache of emissions for carbon prices
+        lb_price: Value of carbon price at lower bound
+        ub_price: Value of carbon price at upper bound
+        emissions_cache: Dictionary of emissions at different price points
+        target: Carbon budget
 
     Returns:
-        Value of lower and upper global carbon price
+        New lower and upper bounds for the carbon price.
     """
-    denominator = max(threshold, 1e-3)
-    if lb < threshold and ub < threshold:
-        # Both prices are too high (emissions too low) -> decrease the lower bound
-        exponent = (ub - threshold) / abs(denominator)  # will be negative
-        exponent = max(exponent, -1)  # cap exponent at -1
-        up = low if (ub >= lb) else up  # new upper bound is price with higher emissions
-        low = low * np.exp(exponent)
+    lb_price_emissions = emissions_cache[lb_price]
+    ub_price_emissions = emissions_cache[ub_price]
 
-    if ub > threshold and lb > threshold:
-        # Both prices are too low (emissions too high) -> increase the upper bound
-        exponent = (lb - threshold) / abs(denominator)  # will be positive
-        exponent = min(exponent, 1)  # cap exponent at 1
-        low = up if (ub >= lb) else low  # new lower bound is price with lower emissions
-        up = up * np.exp(exponent)
+    if lb_price_emissions < target and ub_price_emissions < target:
+        # Emissions too low at both prices -> decrease prices
+        method = decrease_bounds
 
-    if ub > threshold and lb < threshold:
+    elif lb_price_emissions > target and ub_price_emissions > target:
+        # Emissions too high at both prices -> increase prices
+        method = increase_bounds
+
+    elif lb_price_emissions > target and ub_price_emissions < target:
         # Threshold is between bounds -> perform bisection
-        midpoint = round((low + up) / 2.0, 2)
-        m = bisect_loop(market, sectors, equilibrium, commodities, midpoint)
-        emissions_cache[midpoint] = m
-        if m < threshold:
-            # Midpoint price is too high -> becomes new upper bound
-            up = midpoint
-        else:
-            # Midpoint price is too low -> becomes new lower bound
-            low = midpoint
+        method = bisect_bounds
 
-    # Inverted bounds (i.e. increasing price leads to increasing emissions)
-    # Unlikely case, but included for completeness
-    if ub < threshold and lb > threshold:
-        midpoint = round((low + up) / 2.0, 2)
-        m = bisect_loop(market, sectors, equilibrium, commodities, midpoint)
-        emissions_cache[midpoint] = m
-        if m > threshold:
-            # Midpoint price is too high -> becomes new upper bound
-            up = midpoint
-        else:
-            # Midpoint price is too low -> becomes new lower bound
-            low = midpoint
+    elif lb_price_emissions < target and ub_price_emissions > target:
+        # Inverted bounds (i.e. increasing price leads to increasing emissions)
+        # Unlikely case, but included for completeness
+        method = bisect_bounds_inverted
 
-    return low, up
+    else:
+        # lb_price_emissions or ub_price_emissions is equal to the target, so we can
+        # return the bounds unchanged
+        return lb_price, ub_price
+
+    return method(
+        lb_price,
+        ub_price,
+        emissions_cache,
+        target,
+    )
 
 
-def bisect_loop(
+def decrease_bounds(
+    lb_price: float, ub_price: float, emissions_cache: dict[float, float], target: float
+) -> tuple[float, float]:
+    """Decreases the lb of the carbon price, and sets the ub to the previous lb."""
+    denominator = max(target, 1e-3)
+    lb_price_emissions = emissions_cache[lb_price]
+    exponent = (lb_price_emissions - target) / abs(denominator)  # will be negative
+    exponent = max(exponent, -1)  # cap exponent at -1
+    ub_price = lb_price
+    lb_price = lb_price * np.exp(exponent)
+    return lb_price, ub_price
+
+
+def increase_bounds(
+    lb_price: float, ub_price: float, emissions_cache: dict[float, float], target: float
+) -> tuple[float, float]:
+    """Increases the ub of the carbon price, and sets the lb to the previous ub."""
+    denominator = max(target, 1e-3)
+    ub_price_emissions = emissions_cache[ub_price]
+    exponent = (ub_price_emissions - target) / abs(denominator)  # will be positive
+    exponent = min(exponent, 1)  # cap exponent at 1
+    lb_price = ub_price
+    ub_price = ub_price * np.exp(exponent)
+    return lb_price, ub_price
+
+
+def bisect_bounds(
+    lb_price: float,
+    ub_price: float,
+    emissions_cache: dict[float, float],
+    target: float,
+) -> tuple[float, float]:
+    """Bisects the bounds of the carbon price."""
+    midpoint = round((lb_price + ub_price) / 2.0, 2)
+    midpoint_emissions = emissions_cache[midpoint]
+    if midpoint_emissions < target:
+        ub_price = midpoint
+    else:
+        lb_price = midpoint
+    return lb_price, ub_price
+
+
+def bisect_bounds_inverted(
+    lb_price: float,
+    ub_price: float,
+    emissions_cache: dict[float, float],
+    target: float,
+) -> tuple[float, float]:
+    """Bisects the bounds of the carbon price, in the case of inverted bounds."""
+    midpoint = round((lb_price + ub_price) / 2.0, 2)
+    midpoint_emissions = emissions_cache[midpoint]
+    if midpoint_emissions > target:
+        ub_price = midpoint
+    else:
+        lb_price = midpoint
+    return lb_price, ub_price
+
+
+def bisect_solve_market(
     market: xr.Dataset,
-    sectors: list,
-    equilibrium: Callable[
-        [xr.Dataset, Sequence[AbstractSector], int], FindEquilibriumResults
-    ],
+    equilibrium: Callable[[xr.Dataset], FindEquilibriumResults],
     commodities: list,
     new_price: float,
 ) -> float:
@@ -568,11 +610,10 @@ def bisect_loop(
     This updates emissions during iterations.
 
     Arguments:
-        market: Market, with the prices, supply, consumption and demand,
-        sectors: List of sectors,
-        equilibrium: Method for searching market equilibrium,
-        commodities: List of carbon-related commodities,
-        new_price: New carbon price from bisection,
+        market: Market, with the prices, supply, consumption and demand
+        equilibrium: Method for searching market equilibrium
+        commodities: List of carbon-related commodities
+        new_price: New carbon price from bisection
 
     Returns:
         Emissions estimated at the new carbon price.
@@ -582,11 +623,11 @@ def bisect_loop(
 
     # Assign new carbon price and solve market
     new_market.prices.loc[{"year": future, "commodity": commodities}] = new_price
-    new_market = equilibrium(new_market, sectors).market
+    new_market = equilibrium(new_market).market
     new_emissions = (
         new_market.supply.sel(year=future, commodity=commodities)
         .sum(["region", "timeslice", "commodity"])
-        .round(decimals=3)
+        .round(decimals=2)
     ).values.item()
 
     return new_emissions

--- a/src/muse/carbon_budget.py
+++ b/src/muse/carbon_budget.py
@@ -435,6 +435,12 @@ def bisection(
             )
         lb = emissions_cache[up]
 
+        # Terminate early if the last 5 solutions are the same
+        if len(emissions_cache) > 5:
+            last_five = list(emissions_cache.values())[-5:]
+            if all(x == last_five[0] for x in last_five):
+                break
+
         # Exit loop if lower or upper bound on emissions is close to threshold
         if abs(ub - threshold) <= abs(tolerance * threshold):
             return low
@@ -457,7 +463,10 @@ def bisection(
 
     # If convergence isn't reached, new price is that with emissions closest to
     # threshold. If multiple prices are equally close, it returns the lowest price
-    message = f"Carbon budget not matched for year {future}."
+    message = (
+        f"Carbon budget could not be matched for year {future}. "
+        "Try increasing the tolerance or sample size."
+    )
     getLogger(__name__).warning(message)
     return min(emissions_cache, key=lambda k: (abs(emissions_cache[k] - threshold), k))
 

--- a/src/muse/carbon_budget.py
+++ b/src/muse/carbon_budget.py
@@ -402,6 +402,8 @@ def bisection(
     Returns:
         New value of global carbon price
     """
+    from logging import getLogger
+
     # We calculate the carbon price and emissions threshold in the forecast year
     future = market.year[-1]
     threshold = carbon_budget.sel(year=future).values.item()
@@ -455,6 +457,8 @@ def bisection(
 
     # If convergence isn't reached, new price is that with emissions closest to
     # threshold. If multiple prices are equally close, it returns the lowest price
+    message = f"Carbon budget not matched for year {future}."
+    getLogger(__name__).warning(message)
     return min(emissions_cache, key=lambda k: (abs(emissions_cache[k] - threshold), k))
 
 

--- a/src/muse/carbon_budget.py
+++ b/src/muse/carbon_budget.py
@@ -413,7 +413,7 @@ def bisection(
     current = market.year[0]
     time_exp = int(future - current)
     low = 0.01
-    up = max(price, 1e-2) * 1.1**time_exp  # i.e. 10% yearly increase on current price
+    up = max(price, 0.01) * 1.1**time_exp  # i.e. 10% yearly increase on current price
 
     # Bisection loop
     emissions_cache: dict[float, float] = {}  # caches emissions for different prices
@@ -423,9 +423,9 @@ def bisection(
             up = min(up, price_too_high_threshold)
         low = max(low, 0.01)
 
-        # Round prices to 3dp
-        low = round(low, 3)
-        up = round(up, 3)
+        # Round prices to 2dp
+        low = round(low, 2)
+        up = round(up, 2)
 
         # Calculate carbon emissions at new bounds
         if low not in emissions_cache:
@@ -513,17 +513,17 @@ def min_max_bisect(
     denominator = max(threshold, 1e-3)
     if lb < threshold and ub < threshold:
         # Both prices are too high (emissions too low) -> decrease the lower bound
-        exp = (lb - threshold) / abs(denominator)  # will be negative
-        exp = max(exp, -1)  # cap exponent at -1
+        exponent = (ub - threshold) / abs(denominator)  # will be negative
+        exponent = max(exponent, -1)  # cap exponent at -1
         up = low if (ub >= lb) else up  # new upper bound is price with higher emissions
-        low = low * np.exp(exp)
+        low = low * np.exp(exponent)
 
     if ub > threshold and lb > threshold:
         # Both prices are too low (emissions too high) -> increase the upper bound
-        exp = 2 * (lb - threshold) / abs(denominator)  # will be positive
-        exp = min(exp, 1)  # cap exponent at 1
+        exponent = (lb - threshold) / abs(denominator)  # will be positive
+        exponent = min(exponent, 1)  # cap exponent at 1
         low = up if (ub >= lb) else low  # new lower bound is price with lower emissions
-        up = up * np.exp(exp)
+        up = up * np.exp(exponent)
 
     if ub > threshold and lb < threshold:
         # Threshold is between bounds -> perform bisection

--- a/src/muse/carbon_budget.py
+++ b/src/muse/carbon_budget.py
@@ -373,8 +373,8 @@ def bisection(
     sample_size: int = 2,
     refine_price: bool = True,
     price_too_high_threshold: float = 10,
-    fitter: str = "slinear",
     tolerance: float = 0.1,
+    early_termination_count: int = 5,
 ) -> float:
     """Applies bisection algorithm to escalate carbon price and meet the budget.
 
@@ -396,8 +396,9 @@ def bisection(
         refine_price: Boolean to decide on whether carbon price should be capped, with
             the upper bound given by price_too_high_threshold
         price_too_high_threshold: Upper limit for carbon price
-        fitter: Not used in this method
         tolerance: Maximum permitted deviation of emissions from the budget
+        early_termination_count: Will terminate the loop early if the last n solutions
+            are the same
 
     Returns:
         New value of global carbon price
@@ -439,10 +440,10 @@ def bisection(
             )
         lb = emissions_cache[up]
 
-        # Terminate early if the last 5 solutions are the same
-        if len(emissions_cache) >= 7:
-            last_five = list(emissions_cache.values())[-5:]
-            if all(x == last_five[0] for x in last_five):
+        # Terminate early if many consecutive emissions are the same
+        if len(emissions_cache) >= early_termination_count + 2:
+            recent_values = list(emissions_cache.values())[-early_termination_count:]
+            if all(x == recent_values[0] for x in recent_values):
                 break
 
         # Exit loop if lower or upper bound on emissions is close to threshold

--- a/src/muse/carbon_budget.py
+++ b/src/muse/carbon_budget.py
@@ -405,7 +405,7 @@ def bisection(
     # We calculate the carbon price and emissions threshold in the forecast year
     future = market.year[-1]
     threshold = carbon_budget.sel(year=future).values.item()
-    price = market.prices.sel(year=future, commodity=commodities).mean().values
+    price = market.prices.sel(year=future, commodity=commodities).mean().values.item()
 
     # Initial lower and upper bounds on carbon price for the bisection algorithm
     current = market.year[0]
@@ -569,6 +569,6 @@ def bisect_loop(
         new_market.supply.sel(year=future, commodity=commodities)
         .sum(["region", "timeslice", "commodity"])
         .round(decimals=3)
-    ).values
+    ).values.item()
 
     return new_emissions

--- a/src/muse/mca.py
+++ b/src/muse/mca.py
@@ -243,40 +243,14 @@ class MCA:
         )
 
     def update_carbon_price(self, market) -> float | None:
-        """Calculates the updated carbon price, if required.
-
-        If the emission calculated for the next time period is larger than the
-        limit, then the carbon price needs to be updated to ensure that whatever the
-        sectors do, the carbon budget limit is not exceeded.
+        """Calculates the updated carbon price.
 
         Arguments:
-            market: Market, with the prices, supply, consumption and demand.
+            market: Market with the prices, supply, consumption and demand.
 
         Returns:
-            The new carbon price or None
+            The new carbon price. If None, the price is not updated.
         """
-        from numpy import median
-
-        # Solve market with current carbon price
-        market, _ = single_year_iteration(market, self.sectors)
-
-        # Calculate emissions and threshold
-        future = market.year[-1]
-        emissions = (
-            market.supply.sel(year=future, commodity=self.carbon_commodities)
-            .sum(["region", "timeslice", "commodity"])
-            .values
-        )
-        threshold = self.carbon_budget.interp(
-            year=future, kwargs=dict(fill_value=self.carbon_budget.isel(year=-1).values)
-        ).values
-
-        # Exit if emissions are within budget, and price cannot be decreased further
-        cp = median(market.prices.sel(commodity=self.carbon_commodities, year=future))
-        if emissions < threshold and not self.debug and cp == 0.0:
-            return None
-
-        # Update carbon price
         new_carbon_price = self.carbon_method(  # type: ignore
             market,
             self.sectors,


### PR DESCRIPTION
# Description

This fixes a number of problems with the bisection method for setting the carbon price when using a carbon budget. 

One problem was with the calculation of initial price bounds. Firstly, the calculation of the current year in `bisection` was just wrong, which often led to `time_exp` being zero (so the upper and lower bounds would be the same). Secondly, it couldn't deal with an initial carbon price of zero (both bounds would then be zero). Thirdly, the bounds were way to narrow so unlikely to capture the solution. These are all fixed.

The main loop in the algorithm was also a mess, including the convergence criteria, so this has been tidied up and simplified (well, pretty much rewritten completely).

The `min_max_bisect` function was also a mess, so this has been tidied and comments added to explain the logic. The inverted bounds case seemed to be only partially implemented, so I've filled this in.

I've also created a `tolerance` parameter which allows the user to define how close emissions need to be to the budget for the loop to terminate (previously this was hard-coded at 10%). For example, adding to the settings file:

```toml
method_options.tolerance = 0.05
```

I've added a warning for users if the algorithm doesn't reach the target emissions for a particular year.

Finally, I think the flow of the algorithm was wrong. It would solve the market to find the prices of all the commodities, then adjust the carbon price with these prices fixed, and then solve again with the final carbon price fixed and all the other prices allowed to change. This meant that the final market won't necessarily be the same as the market settled on in the bisection algorithm, so emissions might be different. I've changed it now so all the prices are allowed to change together (i.e. every time the carbon price is changed, the other commodity prices are also allowed to change). The main code change to achieve this was to remove the `1` from the `new_market = equilibrium(...` line in `bisect_loop`, and also remove the the initial market solve from `update_carbon_price`. It might take longer to run now, but I think this is necessary.

It's possible that some of these changes might break the other carbon budget algorithm (`fitting`), and some of the improvements I've made here could also be applied to that algorithm, but I've opened up another PR (#484) to deal with that.

I've also added a new tutorial explaining how to use the carbon budget, but keeping that separate to make reviewing easier (#486). You can see the tutorial [here](https://muse-os.readthedocs.io/en/documentation/user-guide/carbon-budget.html)

This will become v1.2.1rc1 once it's ready, so I've gone ahead and bumped the version

## Type of change

Please add a line in the relevant section of
[CHANGELOG.md](https://github.com/EnergySystemsModellingLab/MUSE_OS/blob/development/CHANGELOG.md) to
document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
