### PR TITLE
Add release notes to documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,20 @@ html_theme = "classic"
 
 
 def github_role(name, rawtext, text, lineno, inliner, options=None, content=None):
+    """Creates links to issues/pull requests on the MUSE_OS GitHub site.
+
+    To use in markdown:
+    {github}`ISSUE_NUMBER` (e.g. {github}`123`)
+
+    To use in rst:
+    :github:`ISSUE_NUMBER` (e.g. :github:`123`)
+
+    In both cases this will create a clickable link (visible as #123) to the relevant
+    GitHub page (i.e. https://github.com/EnergySystemsModellingLab/MUSE_OS/issues/123)
+
+    The base URL is for the issues page, but this will also work for pull requests and
+    discussions, as GitHub will automatically redirect to the appropriate page.
+    """
     base_url = "https://github.com/EnergySystemsModellingLab/MUSE_OS/issues/"
     url = f"{base_url}{text}"
     node = nodes.reference(rawtext, f"#{text}", refuri=url, **(options or {}))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,9 @@
 # http://www.sphinx-doc.org/en/master/config
 # -- Project information -----------------------------------------------------
 
+from docutils import nodes
+from docutils.parsers.rst import roles
+
 project = "MUSE"
 copyright = "2024, Imperial College London"
 author = "Imperial College London"
@@ -61,3 +64,15 @@ graphviz_output_format = "svg"
 # -- Options for HTML output -------------------------------------------------
 
 html_theme = "classic"
+
+# -- Render GitHub links -------------------------------------------------
+
+
+def github_role(name, rawtext, text, lineno, inliner, options=None, content=None):
+    base_url = "https://github.com/EnergySystemsModellingLab/MUSE_OS/issues/"
+    url = f"{base_url}{text}"
+    node = nodes.reference(rawtext, f"#{text}", refuri=url, **(options or {}))
+    return [node], []
+
+
+roles.register_canonical_role("github", github_role)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ ModUlar energy system Simulation Environment: MUSE
    advanced-guide/index
    faq
    api
+   release-notes/index
 
 
 Indices and tables

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -5,8 +5,9 @@ This is the list of changes to MUSE between each release.
 
 .. toctree::
    :maxdepth: 1
+   :hidden:
 
    v1.2.3
    v1.2.2
-   v2.2.1
-   v2.2.0
+   v1.2.1
+   v1.2.0

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -1,0 +1,12 @@
+Release notes
+=============
+
+This is the list of changes to MUSE between each release.
+
+.. toctree::
+   :maxdepth: 1
+
+   v1.2.3
+   v1.2.2
+   v2.2.1
+   v2.2.0

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -5,7 +5,6 @@ This is the list of changes to MUSE between each release.
 
 .. toctree::
    :maxdepth: 1
-   :hidden:
 
    v1.2.3
    v1.2.2

--- a/docs/release-notes/v1.2.0.md
+++ b/docs/release-notes/v1.2.0.md
@@ -11,28 +11,28 @@ Please read carefully if upgrading from an earlier version, as some of the chang
 
 ## Model settings
 
-- The default `demand_share` has changed from "new_and_retro" to "standard_demand" (#349). If your model uses retrofit agents, you MUST explicitly specify `demand_share = "new_and_retro"` for all relevant sectors. If this is left out, the model will try to use the "standard_demand" share and will fail. See updated documentation about this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/toml.html#standard-sectors).
-- The default value for `maximum_iterations` has changed from 3 to 100 (#386)
+- The default `demand_share` has changed from "new_and_retro" to "standard_demand" ({github}`349`). If your model uses retrofit agents, you MUST explicitly specify `demand_share = "new_and_retro"` for all relevant sectors. If this is left out, the model will try to use the "standard_demand" share and will fail. See updated documentation about this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/toml.html#standard-sectors).
+- The default value for `maximum_iterations` has changed from 3 to 100 ({github}`386`)
 
 ## Input files
 
-- The `Level` column is no longer required in the `Technodata`  and `CommOut` files, as this parameter isn't used and never has been (#374 and #377). See updated documentation about this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/commodities_io.html).
+- The `Level` column is no longer required in the `Technodata`  and `CommOut` files, as this parameter isn't used and never has been ({github}`374` and {github}`377`). See updated documentation about this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/commodities_io.html).
 - The `ProcessName` column is no longer required in consumption files specified in the _consumption_path_ format. See updated documentation [here](https://muse-os.readthedocs.io/en/latest/inputs/toml.html#preset-sectors). Users are encouraged to remove this column from their files (summing rows for different processes if necessary), as this more accurately depicts how this data is used in the model.
 
 ## Output files
 
-- We have changed how timeslices are represented in some of the output files (#412), so this now follows a consistent format across all files. Some of your downstream scripts for loading and analysing these output files may need to be updated.
-- Previously it was necessary to specify `index = true` (in `settings.toml`) for some of the outputs to prevent some important columns from being dropped. This is no longer required, and users should no longer require the `index` parameter for any reason (#412).
+- We have changed how timeslices are represented in some of the output files ({github}`412`), so this now follows a consistent format across all files. Some of your downstream scripts for loading and analysing these output files may need to be updated.
+- Previously it was necessary to specify `index = true` (in `settings.toml`) for some of the outputs to prevent some important columns from being dropped. This is no longer required, and users should no longer require the `index` parameter for any reason ({github}`412`).
 
 ## Model
 
-- Fixed a bug with the calculation of commodity prices (#418), which affects all models that have multiple timeslices and `maximum_iterations` > 1.
-- Fixed a bug which was preventing the convergence criteria in the MCA algorithm from being properly checked (#407). This will likely affect the results of most models that have `maximum_iterations` > 1.
-- The `minimum_service_factor` parameter was previously being applied incorrectly - this has been fixed (#388).
-- Constraints specified in the `settings.toml` file (with the `constraints` key) were previously being ignored (the model would always revert to the default list of constraints). This has been fixed (#354).
-- We have added a constraint that limits installed capacity to be no greater than that required to meet peak demand (#355). This is applied by default, however if you are manually overriding the defaults in the settings file with the `constraints` key, you MUST include "demand_limiting_capacity" in this list otherwise this constraint won't be used. Note that this only applies to the scipy solver (`lpsolver = "scipy"` in `settings.toml`), not the adhoc solver.
-- Fixed a bug with the calculation of LCOE in models that have a utilization factor of zero for some timeslices (#304)
-- Fixed a bug with the weighted_sum decision method (#449)
+- Fixed a bug with the calculation of commodity prices ({github}`418`), which affects all models that have multiple timeslices and `maximum_iterations` > 1.
+- Fixed a bug which was preventing the convergence criteria in the MCA algorithm from being properly checked ({github}`407`). This will likely affect the results of most models that have `maximum_iterations` > 1.
+- The `minimum_service_factor` parameter was previously being applied incorrectly - this has been fixed ({github}`388`).
+- Constraints specified in the `settings.toml` file (with the `constraints` key) were previously being ignored (the model would always revert to the default list of constraints). This has been fixed ({github}`354`).
+- We have added a constraint that limits installed capacity to be no greater than that required to meet peak demand ({github}`355`). This is applied by default, however if you are manually overriding the defaults in the settings file with the `constraints` key, you MUST include "demand_limiting_capacity" in this list otherwise this constraint won't be used. Note that this only applies to the scipy solver (`lpsolver = "scipy"` in `settings.toml`), not the adhoc solver.
+- Fixed a bug with the calculation of LCOE in models that have a utilization factor of zero for some timeslices ({github}`304`)
+- Fixed a bug with the weighted_sum decision method ({github}`449`)
 
 ## Other notes
 

--- a/docs/release-notes/v1.2.0.md
+++ b/docs/release-notes/v1.2.0.md
@@ -1,42 +1,30 @@
-_The following guide should be read by all users upgrading from v1.1.0 or earlier. Please read through carefully, as some of the changes may require you to modify your model input files or downstream analysis scripts._
+# Release notes for MUSE v1.2.0 (September 19, 2024)
 
-## Installation
+These are the main changes in MUSE v1.2.0.
 
-### Virtual environment installation
+Please read carefully if upgrading from an earlier version, as some of the changes may require you to modify your model input files or downstream analysis scripts.
 
-If you have previously installed MUSE within a virtual environment using the instructions [here](https://muse-os.readthedocs.io/en/latest/installation/virtual-env-based.html), you can update MUSE by activating your virtual environment and running `pip install --upgrade muse-os`
+## Dropped support for Python 3.8
 
-If you were previously using Python 3.8, you must create a new environment using 3.9 or later. There are instructions on setting up a new environment with the appropriate Python version [here](https://muse-os.readthedocs.io/en/latest/installation/virtual-env-based.html)
+- MUSE is now compatible with Python versions 3.9 to 3.12
+- If you were previously using Python 3.8, you must create a new environment using 3.9 or later. There are instructions on setting up a new environment with the appropriate Python version [here](https://muse-os.readthedocs.io/en/latest/installation/virtual-env-based.html)
 
-### Developer installation
-
-If you have already installed the developer version of MUSE using the instructions [here](https://muse-os.readthedocs.io/en/latest/installation/developers.html), you can update it to the latest version by doing the following:
-
-- Activate the environment that you used for the developer installation
-- Navigate to your `MUSE_OS` folder in the terminal
-- Run `git checkout main`, followed by `git pull` to get the latest version of the code
-- To update package dependencies, run `pip install -e .[dev,doc]`
-
-As above, if you were previously using Python 3.8, you must set up the installation from scratch using 3.9 or later.
-
-## Changes
-
-### Model settings
+## Model settings
 
 - The default `demand_share` has changed from "new_and_retro" to "standard_demand" (#349). If your model uses retrofit agents, you MUST explicitly specify `demand_share = "new_and_retro"` for all relevant sectors. If this is left out, the model will try to use the "standard_demand" share and will fail. See updated documentation about this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/toml.html#standard-sectors).
 - The default value for `maximum_iterations` has changed from 3 to 100 (#386)
 
-### Input files
+## Input files
 
 - The `Level` column is no longer required in the `Technodata`  and `CommOut` files, as this parameter isn't used and never has been (#374 and #377). See updated documentation about this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/commodities_io.html).
 - The `ProcessName` column is no longer required in consumption files specified in the _consumption_path_ format. See updated documentation [here](https://muse-os.readthedocs.io/en/latest/inputs/toml.html#preset-sectors). Users are encouraged to remove this column from their files (summing rows for different processes if necessary), as this more accurately depicts how this data is used in the model.
 
-### Output files
+## Output files
 
 - We have changed how timeslices are represented in some of the output files (#412), so this now follows a consistent format across all files. Some of your downstream scripts for loading and analysing these output files may need to be updated.
 - Previously it was necessary to specify `index = true` (in `settings.toml`) for some of the outputs to prevent some important columns from being dropped. This is no longer required, and users should no longer require the `index` parameter for any reason (#412).
 
-### Model
+## Model
 
 - Fixed a bug with the calculation of commodity prices (#418), which affects all models that have multiple timeslices and `maximum_iterations` > 1.
 - Fixed a bug which was preventing the convergence criteria in the MCA algorithm from being properly checked (#407). This will likely affect the results of most models that have `maximum_iterations` > 1.

--- a/docs/release-notes/v1.2.0.md
+++ b/docs/release-notes/v1.2.0.md
@@ -1,0 +1,58 @@
+_The following guide should be read by all users upgrading from v1.1.0 or earlier. Please read through carefully, as some of the changes may require you to modify your model input files or downstream analysis scripts._
+
+## Installation
+
+### Virtual environment installation
+
+If you have previously installed MUSE within a virtual environment using the instructions [here](https://muse-os.readthedocs.io/en/latest/installation/virtual-env-based.html), you can update MUSE by activating your virtual environment and running `pip install --upgrade muse-os`
+
+If you were previously using Python 3.8, you must create a new environment using 3.9 or later. There are instructions on setting up a new environment with the appropriate Python version [here](https://muse-os.readthedocs.io/en/latest/installation/virtual-env-based.html)
+
+### Developer installation
+
+If you have already installed the developer version of MUSE using the instructions [here](https://muse-os.readthedocs.io/en/latest/installation/developers.html), you can update it to the latest version by doing the following:
+
+- Activate the environment that you used for the developer installation
+- Navigate to your `MUSE_OS` folder in the terminal
+- Run `git checkout main`, followed by `git pull` to get the latest version of the code
+- To update package dependencies, run `pip install -e .[dev,doc]`
+
+As above, if you were previously using Python 3.8, you must set up the installation from scratch using 3.9 or later.
+
+## Changes
+
+### Model settings
+
+- The default `demand_share` has changed from "new_and_retro" to "standard_demand" (#349). If your model uses retrofit agents, you MUST explicitly specify `demand_share = "new_and_retro"` for all relevant sectors. If this is left out, the model will try to use the "standard_demand" share and will fail. See updated documentation about this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/toml.html#standard-sectors).
+- The default value for `maximum_iterations` has changed from 3 to 100 (#386)
+
+### Input files
+
+- The `Level` column is no longer required in the `Technodata`  and `CommOut` files, as this parameter isn't used and never has been (#374 and #377). See updated documentation about this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/commodities_io.html).
+- The `ProcessName` column is no longer required in consumption files specified in the _consumption_path_ format. See updated documentation [here](https://muse-os.readthedocs.io/en/latest/inputs/toml.html#preset-sectors). Users are encouraged to remove this column from their files (summing rows for different processes if necessary), as this more accurately depicts how this data is used in the model.
+
+### Output files
+
+- We have changed how timeslices are represented in some of the output files (#412), so this now follows a consistent format across all files. Some of your downstream scripts for loading and analysing these output files may need to be updated.
+- Previously it was necessary to specify `index = true` (in `settings.toml`) for some of the outputs to prevent some important columns from being dropped. This is no longer required, and users should no longer require the `index` parameter for any reason (#412).
+
+### Model
+
+- Fixed a bug with the calculation of commodity prices (#418), which affects all models that have multiple timeslices and `maximum_iterations` > 1.
+- Fixed a bug which was preventing the convergence criteria in the MCA algorithm from being properly checked (#407). This will likely affect the results of most models that have `maximum_iterations` > 1.
+- The `minimum_service_factor` parameter was previously being applied incorrectly - this has been fixed (#388).
+- Constraints specified in the `settings.toml` file (with the `constraints` key) were previously being ignored (the model would always revert to the default list of constraints). This has been fixed (#354).
+- We have added a constraint that limits installed capacity to be no greater than that required to meet peak demand (#355). This is applied by default, however if you are manually overriding the defaults in the settings file with the `constraints` key, you MUST include "demand_limiting_capacity" in this list otherwise this constraint won't be used. Note that this only applies to the scipy solver (`lpsolver = "scipy"` in `settings.toml`), not the adhoc solver.
+- Fixed a bug with the calculation of LCOE in models that have a utilization factor of zero for some timeslices (#304)
+- Fixed a bug with the weighted_sum decision method (#449)
+
+## Other notes
+
+- Please don't use the "metric_supply", "metricy_supply", "timeslice_supply", "yearly_supply", "metric_consumption", "metricy_consumption", "timeslice_consumption" or "yearly_consumption" outputs, as these sometimes give incorrect values and will likely be deleted in the future. You should be able to get everything you need by using the "supply" and "consumption" outputs within each sector, for example (replacing `SECTOR_NAME` with the name of the sector):
+
+  ```toml
+  [[sectors.SECTOR_NAME.outputs]]
+  filename = '{cwd}/{default_output_dir}/{Sector}/{Quantity}.csv'
+  quantity = "supply"
+  sink = "aggregate"
+  ```

--- a/docs/release-notes/v1.2.1.md
+++ b/docs/release-notes/v1.2.1.md
@@ -6,7 +6,7 @@ Please read carefully if upgrading from an earlier version, as some of the chang
 
 ## Carbon budget module
 
-- The bisection method has been fixed, as this was not working as expected before (#483, #484). Additionally, a number of default settings have been changed, and parameters renamed. Users must carefully check which parameters are specified in their settings files, as any unspecified parameters will revert to the new defaults. The main changes are as follows:
+- The bisection method has been fixed, as this was not working as expected before ({github}`483`, {github}`484`). Additionally, a number of default settings have been changed, and parameters renamed. Users must carefully check which parameters are specified in their settings files, as any unspecified parameters will revert to the new defaults. The main changes are as follows:
   - `control_undershoot` / `control_overshoot`: The default has been changed from True to False
   - `method`: The default has changed from `fitting` to `bisection`
   - `method_options.refine_price`: The default has changed from True to False
@@ -18,9 +18,9 @@ __Please read the [new documentation page](https://muse-os.readthedocs.io/en/doc
 
 ## Default model
 
-- A number of changes have been made to the default model that is generated with `muse --model default --copy PATH`. This is mostly to simplify the outputs (#461)
+- A number of changes have been made to the default model that is generated with `muse --model default --copy PATH`. This is mostly to simplify the outputs ({github}`461`)
 
 ## Tutorials
 
-- The tutorials have been simplified and re-ordered (#470)
-- A tutorial has been added explaining the use of a carbon budget (#486)
+- The tutorials have been simplified and re-ordered ({github}`470`)
+- A tutorial has been added explaining the use of a carbon budget ({github}`486`)

--- a/docs/release-notes/v1.2.1.md
+++ b/docs/release-notes/v1.2.1.md
@@ -1,14 +1,10 @@
-_The following guide should be read by all users upgrading from v1.2.0. Please read through carefully, as some of the changes may require you to modify your model input files or downstream analysis scripts._
+# Release notes for MUSE v1.2.1 (October 9, 2024)
 
-## Installation
+These are the main changes in MUSE v1.2.1.
 
-If you have previously installed MUSE within a virtual environment, you can update MUSE by activating your virtual environment and running `pip install --upgrade muse-os`
+Please read carefully if upgrading from an earlier version, as some of the changes may require you to modify your model input files.
 
-If you installed MUSE using a different method, please consult the documentation.
-
-## Changes
-
-### Carbon budget module
+## Carbon budget module
 
 - The bisection method has been fixed, as this was not working as expected before (#483, #484). Additionally, a number of default settings have been changed, and parameters renamed. Users must carefully check which parameters are specified in their settings files, as any unspecified parameters will revert to the new defaults. The main changes are as follows:
   - `control_undershoot` / `control_overshoot`: The default has been changed from True to False
@@ -20,13 +16,11 @@ If you installed MUSE using a different method, please consult the documentation
 
 __Please read the [new documentation page](https://muse-os.readthedocs.io/en/documentation/inputs/toml.html#carbon-market) in full before using a carbon budget__
 
-__Edit 20/10/24:__ _MUSE will throw an error if no `method_options` are specified in the toml file (i.e. if you want to use the default option for all parameters). This is a known bug which will be fixed in v1.2.3, but for now please make that at least one `method_option` parameter is specified in the toml file (e.g. `method_options.max_iterations = 5`), or explicitly build an empty dictionary by including the following line: `[carbon_budget_control.method_options]`_
-
-### Default model
+## Default model
 
 - A number of changes have been made to the default model that is generated with `muse --model default --copy PATH`. This is mostly to simplify the outputs (#461)
 
-### Tutorials
+## Tutorials
 
 - The tutorials have been simplified and re-ordered (#470)
 - A tutorial has been added explaining the use of a carbon budget (#486)

--- a/docs/release-notes/v1.2.1.md
+++ b/docs/release-notes/v1.2.1.md
@@ -1,0 +1,32 @@
+_The following guide should be read by all users upgrading from v1.2.0. Please read through carefully, as some of the changes may require you to modify your model input files or downstream analysis scripts._
+
+## Installation
+
+If you have previously installed MUSE within a virtual environment, you can update MUSE by activating your virtual environment and running `pip install --upgrade muse-os`
+
+If you installed MUSE using a different method, please consult the documentation.
+
+## Changes
+
+### Carbon budget module
+
+- The bisection method has been fixed, as this was not working as expected before (#483, #484). Additionally, a number of default settings have been changed, and parameters renamed. Users must carefully check which parameters are specified in their settings files, as any unspecified parameters will revert to the new defaults. The main changes are as follows:
+  - `control_undershoot` / `control_overshoot`: The default has been changed from True to False
+  - `method`: The default has changed from `fitting` to `bisection`
+  - `method_options.refine_price`: The default has changed from True to False
+  - `method_options.resolution`: New parameter
+  - `method_options.sample_size`: This parameter no longer applies to the bisection algorithm, and won't be permitted when using that method. Please use `method_options.max_iterations` instead
+  - `method_options.tolerance` and `method_options.early_termination_count`: New parameters for the bisection method
+
+__Please read the [new documentation page](https://muse-os.readthedocs.io/en/documentation/inputs/toml.html#carbon-market) in full before using a carbon budget__
+
+__Edit 20/10/24:__ _MUSE will throw an error if no `method_options` are specified in the toml file (i.e. if you want to use the default option for all parameters). This is a known bug which will be fixed in v1.2.3, but for now please make that at least one `method_option` parameter is specified in the toml file (e.g. `method_options.max_iterations = 5`), or explicitly build an empty dictionary by including the following line: `[carbon_budget_control.method_options]`_
+
+### Default model
+
+- A number of changes have been made to the default model that is generated with `muse --model default --copy PATH`. This is mostly to simplify the outputs (#461)
+
+### Tutorials
+
+- The tutorials have been simplified and re-ordered (#470)
+- A tutorial has been added explaining the use of a carbon budget (#486)

--- a/docs/release-notes/v1.2.2.md
+++ b/docs/release-notes/v1.2.2.md
@@ -1,14 +1,8 @@
-October 28, 2024
+# Release notes for MUSE v1.2.2 (October 28, 2024)
 
-## Installation
+These are the main changes in MUSE v1.2.2.
 
-If you have previously installed MUSE within a virtual environment, you can update MUSE by activating your virtual environment and running `pip install --upgrade muse-os`
-
-If you installed MUSE using a different method, please consult the documentation.
-
-## Changes
-
-### Bug fixes
+## Bug fixes
 
 This release fixes several errors in calculations related to the utilization factor, minimum service factor and commodity prices. Interested readers can follow the discussions in the following pull requests:
 

--- a/docs/release-notes/v1.2.2.md
+++ b/docs/release-notes/v1.2.2.md
@@ -1,0 +1,19 @@
+October 28, 2024
+
+## Installation
+
+If you have previously installed MUSE within a virtual environment, you can update MUSE by activating your virtual environment and running `pip install --upgrade muse-os`
+
+If you installed MUSE using a different method, please consult the documentation.
+
+## Changes
+
+### Bug fixes
+
+This release fixes several errors in calculations related to the utilization factor, minimum service factor and commodity prices. Interested readers can follow the discussions in the following pull requests:
+
+- #368
+- #518
+- #534
+
+Developers should pay particular attention to the latter two PRs, to avoid introducing similar mistakes in the future.

--- a/docs/release-notes/v1.2.2.md
+++ b/docs/release-notes/v1.2.2.md
@@ -6,8 +6,8 @@ These are the main changes in MUSE v1.2.2.
 
 This release fixes several errors in calculations related to the utilization factor, minimum service factor and commodity prices. Interested readers can follow the discussions in the following pull requests:
 
-- #368
-- #518
-- #534
+- {github}`368`
+- {github}`518`
+- {github}`534`
 
 Developers should pay particular attention to the latter two PRs, to avoid introducing similar mistakes in the future.

--- a/docs/release-notes/v1.2.3.md
+++ b/docs/release-notes/v1.2.3.md
@@ -12,7 +12,7 @@ Please read carefully if upgrading from an earlier version, as some of the chang
 ## `MaxCapacityGrowth` parameter (#565)
 
 - The definition of this parameter has changed to compound growth rather than linear growth. It can now be properly interpreted as the maximum growth of the technology per year. See the documentation for this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/technodata.html)
-- To give an example, if a 5 year time period is being used, a value of 0.5 previously meant that capacity was allowed to grow by 250% over the time period (0.5 *5* 100), but with compound growth the limit is now 660% (((1.5 ** 5) - 1) * 100)
+- To give an example, if a 5 year time period is being used, a value of 0.5 previously meant that capacity was allowed to grow by 250% over the time period (0.5 x 5 x 100), but with compound growth the limit is now 660% (((1.5 ** 5) - 1) x 100)
 - Users may see results change as a result of this.
 
 ## Material and Variable costs (#563)

--- a/docs/release-notes/v1.2.3.md
+++ b/docs/release-notes/v1.2.3.md
@@ -4,22 +4,22 @@ These are the main changes in MUSE v1.2.0.
 
 Please read carefully if upgrading from an earlier version, as some of the changes may require you to modify your model input files.
 
-## Log files (#560)
+## Log files ({github}`560`)
 
 - MUSE will now output two log files to the results folder whenever a simulation is run: one (`muse_info.log`) containing info and debug messages, and the other (`muse_warning.log`) containing warning messages.
 - Users are particularly encouraged to consult the `muse_warnings.log` file after each run, and pay attention to any messages shown.
 
-## `MaxCapacityGrowth` parameter (#565)
+## `MaxCapacityGrowth` parameter ({github}`565`)
 
 - The definition of this parameter has changed to compound growth rather than linear growth. It can now be properly interpreted as the maximum growth of the technology per year. See the documentation for this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/technodata.html)
 - To give an example, if a 5 year time period is being used, a value of 0.5 previously meant that capacity was allowed to grow by 250% over the time period (0.5 x 5 x 100), but with compound growth the limit is now 660% (((1.5 ** 5) - 1) x 100)
 - Users may see results change as a result of this.
 
-## Material and Variable costs (#563)
+## Material and Variable costs ({github}`563`)
 
 - Fixes errors in the calculation of material and variable costs, particularly in the case of technologies with output quantities not equal to 1. See #563 for details
-- This effects decision metrics, but doesn't directly effect commodity prices. There are known issues remaining in the calculation of commodity prices (#551, #552), which will be fixed separately
+- This effects decision metrics, but doesn't directly effect commodity prices. There are known issues remaining in the calculation of commodity prices ({github}`551`, {github}`552`), which will be fixed separately
 
 ## Minor bug fixes
 
-- Fixed an error introduced in v1.2.1 which caused carbon budget simulations to fail if no method options were specified (#539)
+- Fixed an error introduced in v1.2.1 which caused carbon budget simulations to fail if no method options were specified ({github}`539`)

--- a/docs/release-notes/v1.2.3.md
+++ b/docs/release-notes/v1.2.3.md
@@ -1,0 +1,29 @@
+November 19, 2024
+
+## Installation
+
+If you have previously installed MUSE within a virtual environment, you can update MUSE by activating your virtual environment and running `pip install --upgrade muse-os`
+
+If you installed MUSE using a different method, please consult the documentation.
+
+## Changes
+
+### Log files (#560)
+
+- MUSE will now output two log files to the results folder whenever a simulation is run: one (`muse_info.log`) containing info and debug messages, and the other (`muse_warning.log`) containing warning messages.
+- Users are particularly encouraged to consult the `muse_warnings.log` file after each run, and pay attention to any messages shown.
+
+### `MaxCapacityGrowth` parameter (#565)
+
+- The definition of this parameter has changed to compound growth rather than linear growth. It can now be properly interpreted as the maximum growth of the technology per year. See the documentation for this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/technodata.html)
+- To give an example, if a 5 year time period is being used, a value of 0.5 previously meant that capacity was allowed to grow by 250% over the time period (0.5 *5* 100), but with compound growth the limit is now 660% (((1.5 ** 5) - 1) * 100)
+- Users may see results change as a result of this.
+
+### Material and Variable costs (#563)
+
+- Fixes errors in the calculation of material and variable costs, particularly in the case of technologies with output quantities not equal to 1. See #563 for details
+- This effects decision metrics, but doesn't directly effect commodity prices. There are known issues remaining in the calculation of commodity prices (#551, #552), which will be fixed separately
+
+### Minor bug fixes
+
+- Fixed an error introduced in v1.2.1 which caused carbon budget simulations to fail if no method options were specified (#539)

--- a/docs/release-notes/v1.2.3.md
+++ b/docs/release-notes/v1.2.3.md
@@ -1,29 +1,25 @@
-November 19, 2024
+# Release notes for MUSE v1.2.3 (November 19, 2024)
 
-## Installation
+These are the main changes in MUSE v1.2.0.
 
-If you have previously installed MUSE within a virtual environment, you can update MUSE by activating your virtual environment and running `pip install --upgrade muse-os`
+Please read carefully if upgrading from an earlier version, as some of the changes may require you to modify your model input files.
 
-If you installed MUSE using a different method, please consult the documentation.
-
-## Changes
-
-### Log files (#560)
+## Log files (#560)
 
 - MUSE will now output two log files to the results folder whenever a simulation is run: one (`muse_info.log`) containing info and debug messages, and the other (`muse_warning.log`) containing warning messages.
 - Users are particularly encouraged to consult the `muse_warnings.log` file after each run, and pay attention to any messages shown.
 
-### `MaxCapacityGrowth` parameter (#565)
+## `MaxCapacityGrowth` parameter (#565)
 
 - The definition of this parameter has changed to compound growth rather than linear growth. It can now be properly interpreted as the maximum growth of the technology per year. See the documentation for this parameter [here](https://muse-os.readthedocs.io/en/latest/inputs/technodata.html)
 - To give an example, if a 5 year time period is being used, a value of 0.5 previously meant that capacity was allowed to grow by 250% over the time period (0.5 *5* 100), but with compound growth the limit is now 660% (((1.5 ** 5) - 1) * 100)
 - Users may see results change as a result of this.
 
-### Material and Variable costs (#563)
+## Material and Variable costs (#563)
 
 - Fixes errors in the calculation of material and variable costs, particularly in the case of technologies with output quantities not equal to 1. See #563 for details
 - This effects decision metrics, but doesn't directly effect commodity prices. There are known issues remaining in the calculation of commodity prices (#551, #552), which will be fixed separately
 
-### Minor bug fixes
+## Minor bug fixes
 
 - Fixed an error introduced in v1.2.1 which caused carbon budget simulations to fail if no method options were specified (#539)


### PR DESCRIPTION
# Description

Adds release notes for versions 1.2.0 to 1.2.3 to the documentation. No problems using markdown, so could pretty much copy and paste these from github. It's all completely manual, but I think that's fine as these should be tailored to users rather than automatically built from PR names or commit messages

I also found a way to link to github issues/PRs without writing out the full URL

You can see what this all looks like [here](https://muse-os.readthedocs.io/en/documentation/)

Fixes #538 