### PR TITLE
Perform the utilisation factor check on the whole technodata dataset

### DIFF
--- a/src/muse/data/example/trade/technodata/gas/CommIn.csv
+++ b/src/muse/data/example/trade/technodata/gas/CommIn.csv
@@ -2,4 +2,3 @@ ProcessName,RegionName,Time,Level,electricity,gas,heat,CO2f,wind
 Unit,-,Year,-,PJ/PJ,PJ/PJ,PJ/PJ,kt/PJ,PJ/PJ
 gassupply1,R1,2010,fixed,0,1,0,0,0
 gassupply1,R2,2010,fixed,0,1,0,0,0
-gassupply1,R3,2010,fixed,0,1,0,0,0

--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -866,7 +866,11 @@ def read_trade(
     return result.rename(src_region="region")
 
 
-def check_utilization_and_minimum_service_factors(data, filename):
+def check_utilization_and_minimum_service_factors(
+    data: pd.DataFrame, filename: Union[str, list[str]]
+) -> None:
+    filename = [filename] if isinstance(filename, (str, Path)) else filename
+    filename = [name for name in filename if name is not None]
     if "utilization_factor" not in data.columns:
         raise ValueError(
             f"""A technology needs to have a utilization factor defined for every
@@ -887,7 +891,7 @@ def _check_utilization_not_all_zero(data, filename):
     if (utilization_sum.utilization_factor == 0).any():
         raise ValueError(
             f"""A technology can not have a utilization factor of 0 for every
-                timeslice. Please check file {filename}."""
+                timeslice. Please check files: {filename}."""
         )
 
 
@@ -896,7 +900,7 @@ def _check_utilization_in_range(data, filename):
     if not np.all((0 <= utilization) & (utilization <= 1)):
         raise ValueError(
             f"""Utilization factor values must all be between 0 and 1 inclusive.
-            Please check file {filename}."""
+            Please check files: {filename}."""
         )
 
 
@@ -913,5 +917,5 @@ def _check_minimum_service_factors_in_range(data, filename):
     if not np.all((0 <= min_service_factor) & (min_service_factor <= 1)):
         raise ValueError(
             f"""Minimum service factor values must all be between 0 and 1 inclusive.
-             Please check file {filename}."""
+             Please check files: {filename}."""
         )

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -779,7 +779,7 @@ def test_check_utilization_and_minimum_service_factors(*mocks):
     )
     check_utilization_and_minimum_service_factors(df, "file.csv")
     for mock in mocks:
-        mock.assert_called_once_with(df, "file.csv")
+        mock.assert_called_once_with(df, ["file.csv"])
 
 
 @patch("muse.readers.csv._check_utilization_in_range")
@@ -796,7 +796,7 @@ def test_check_utilization_and_minimum_service_factors_no_min(
     df = pd.DataFrame({"utilization_factor": (0, 0, 1)})
     check_utilization_and_minimum_service_factors(df, "file.csv")
     for mock in mocks:
-        mock.assert_called_once_with(df, "file.csv")
+        mock.assert_called_once_with(df, ["file.csv"])
     min_service_factor_mock.assert_not_called()
     utilization_below_min_mock.assert_not_called()
 


### PR DESCRIPTION
# Description

After all relevant files have been loaded, as per @tsmbland suggestion. I spotted what felt like a left-over R3 in the trade technodata and that cause the tests to fail. 

The approach is not the most elegant one - take thw whole xarray dataset, transform it to a pandas dataframe and perform the checks as before. Not the best performance-wise, but as this is done only once at the begining, performance is not an issue so opted for the path of minimum effort. 

Fixes #513

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass: `$ python -m pytest`
- [x] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
