### PR TITLE
Pass technology data only for investment year to constraints

### DIFF
--- a/src/muse/agents/agent.py
+++ b/src/muse/agents/agent.py
@@ -334,13 +334,16 @@ class InvestingAgent(Agent):
         ).values
         search = search.sel(asset=condtechs)
 
+        # Get technology parameters for the investment year
+        techs = self.filter_input(technologies, year=current_year + time_period)
+
         # Calculate constraints
         constraints = self.constraints(
             search.demand,
             self.assets,
             search.search_space,
             market,
-            technologies,
+            techs,
             year=current_year,
             timeslice_level=self.timeslice_level,
         )

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -180,6 +180,7 @@ def register_constraints(function: CONSTRAINT_SIGNATURE) -> CONSTRAINT_SIGNATURE
         **kwargs,
     ) -> Constraint | None:
         """Computes and standardizes a constraint."""
+        assert "year" not in technologies.dims
         constraint = function(  # type: ignore
             demand, assets, search_space, market, technologies, **kwargs
         )
@@ -252,7 +253,6 @@ def factory(
     ) -> list[Constraint]:
         if year is None:
             year = int(market.year.min())
-        assert "year" not in technologies.dims
         constraints = [
             function(
                 demand,

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -922,8 +922,8 @@ def lp_constraint_matrix(
          >>> from muse import examples
          >>> from muse import constraints as cs
          >>> res = examples.sector("residential", model="medium")
-         >>> technologies = res.technologies
          >>> market = examples.residential_market("medium")
+         >>> technologies = res.technologies.sel(year=market.year.min() + 5)
          >>> search = examples.search_space("residential", model="medium")
          >>> assets = next(a.assets for a in res.agents)
          >>> demand = None # not used in max production
@@ -932,8 +932,6 @@ def lp_constraint_matrix(
          >>> lpcosts = cs.lp_costs(
          ...     (
          ...         technologies
-         ...         .interp(year=market.year.min() + 5)
-         ...         .drop_vars("year")
          ...         .sel(region=assets.region)
          ...     ),
          ...     costs=search * np.arange(np.prod(search.shape)).reshape(search.shape),
@@ -1059,15 +1057,16 @@ class ScipyAdapter:
         >>> from muse import constraints as cs
         >>> res = examples.sector("residential", model="medium")
         >>> market = examples.residential_market("medium")
+        >>> technologies = res.technologies.sel(year=market.year.min() + 5)
         >>> search = examples.search_space("residential", model="medium")
         >>> assets = next(a.assets for a in res.agents)
         >>> market_demand =  0.8 * maximum_production(
-        ...     res.technologies.interp(year=2025),
+        ...     technologies,
         ...     assets.capacity.sel(year=2025).groupby("technology").sum("asset"),
         ... ).rename(technology="asset")
         >>> costs = search * np.arange(np.prod(search.shape)).reshape(search.shape)
         >>> constraint = cs.max_capacity_expansion(
-        ...     market_demand, assets, search, market, res.technologies,
+        ...     market_demand, assets, search, market, technologies,
         ... )
 
         The constraint acts over capacity decision variables only:

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -252,6 +252,7 @@ def factory(
     ) -> list[Constraint]:
         if year is None:
             year = int(market.year.min())
+        assert "year" not in technologies.dims
         constraints = [
             function(
                 demand,
@@ -361,7 +362,6 @@ def max_capacity_expansion(
             ["max_capacity_addition", "max_capacity_growth", "total_capacity_limit"]
         ],
         technology=replacement,
-        year=year,
     ).drop_vars("technology")
     regions = getattr(capacity, "region", None)
     if regions is not None and "region" in technologies.dims:
@@ -475,7 +475,7 @@ def max_production(
     replacement = replacement.drop_vars(
         [u for u in replacement.coords if u not in replacement.dims]
     )
-    kwargs = dict(technology=replacement, year=year, commodity=commodities)
+    kwargs = dict(technology=replacement, commodity=commodities)
     if "region" in search_space.coords and "region" in technologies.dims:
         kwargs["region"] = search_space.region
     techs = (
@@ -756,7 +756,7 @@ def minimum_service(
     replacement = replacement.drop_vars(
         [u for u in replacement.coords if u not in replacement.dims]
     )
-    kwargs = dict(technology=replacement, year=year, commodity=commodities)
+    kwargs = dict(technology=replacement, commodity=commodities)
     if "region" in search_space.coords and "region" in technologies.dims:
         kwargs["region"] = assets.region
     techs = (

--- a/tests/test_trade.py
+++ b/tests/test_trade.py
@@ -23,7 +23,7 @@ def constraints_args(sector="power", model="trade") -> Mapping[str, Any]:
         assets=assets,
         search_space=search_space,
         market=market,
-        technologies=power.technologies,
+        technologies=power.technologies.sel(year=market.year.min(), drop=True),
     )
 
 
@@ -60,8 +60,7 @@ def test_max_production(constraints_args):
     }
     assert set(constraint.capacity.dims) == dims
     assert set(constraint.production.dims) == dims
-    assert constraint.year.dims == ()
-    assert set(constraint.agent.coords) == {"region", "agent", "year"}
+    assert set(constraint.agent.coords) == {"region", "agent"}
 
 
 def test_minimum_service(constraints_args):
@@ -76,8 +75,7 @@ def test_minimum_service(constraints_args):
     assert set(constraint.production.dims) == dims
     assert set(constraint.b.dims) == dims
     assert (constraint.capacity <= 0).all()
-    assert constraint.year.dims == ()
-    assert set(constraint.asset.coords) == {"region", "agent", "year"}
+    assert set(constraint.asset.coords) == {"region", "agent"}
 
 
 def test_search_space(constraints_args):


### PR DESCRIPTION
Constraints should only use technology parameters for a single year (the investment year), so being explicit about this by passing the constraints only the data they need