### PR TITLE
Pin xarray version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy>=2.0",
     "scipy>=1.13",
     "pandas>=2.2",
-    "xarray>=2024.6",
+    "xarray>=2024.6,<=2024.11",
     "bottleneck>=1.4",
     "coloredlogs",
     "toml",


### PR DESCRIPTION
Regression tests broken from xarray v2025.1. I couldn't figure out why, so I'm pinning the version for now. Will open up another issue about this

Close #623