### PR TITLE
Cleaner passing of current year/investment year

### DIFF
--- a/src/muse/agents/agent.py
+++ b/src/muse/agents/agent.py
@@ -87,7 +87,16 @@ class AbstractAgent(ABC):
         market: xr.Dataset,
         demand: xr.DataArray,
     ) -> None:
-        """Increments agent to the next time point (e.g. performing investments)."""
+        """Increments agent to the next time point (e.g. performing investments).
+
+        Performs investments to meet demands, and increments agent.year to the
+        investment year.
+
+        Arguments:
+            technologies: dataset of technology parameters for the investment year
+            market: market dataset covering the current year and investment year
+            demand: data array of demand for the investment year
+        """
 
     def __repr__(self):
         return (
@@ -167,13 +176,12 @@ class Agent(AbstractAgent):
             timeslice_level=timeslice_level,
         )
 
-        self.year = year
         """ Current year. Incremented by one every time next is called."""
-        self.forecast = forecast
+        self.year = year
+
         """Number of years to look into the future for forecating purposed."""
-        if search_rules is None:
-            search_rules = filter_factory()
-        self.search_rules: Callable = search_rules
+        self.forecast = forecast
+
         """Search rule(s) determining potential replacement technologies.
 
         This is a string referring to a filter, or a sequence of strings
@@ -181,25 +189,29 @@ class Agent(AbstractAgent):
         function registered via `muse.filters.register_filter` can be
         used to filter the search space.
         """
-        self.maturity_threshold = maturity_threshold
+        if search_rules is None:
+            search_rules = filter_factory()
+        self.search_rules: Callable = search_rules
+
         """ Market share threshold.
 
         Threshold when and if filtering replacement technologies with respect
         to market share.
         """
+        self.maturity_threshold = maturity_threshold
+
         self.spend_limit = spend_limit
 
+        """One or more objectives by which to decide next investments."""
         if objectives is None:
             objectives = objectives_factory()
         self.objectives = objectives
-        """One or more objectives by which to decide next investments."""
+
+        """Creates single decision objective from one or more objectives."""
         if decision is None:
             decision = decision_factory()
         self.decision = decision
-        """Creates single decision objective from one or more objectives."""
-        if housekeeping is None:
-            housekeeping = housekeeping_factory()
-        self._housekeeping = housekeeping
+
         """Transforms applied on the assets at the start of each iteration.
 
         It could mean keeping the assets as are, or removing assets with no
@@ -207,23 +219,29 @@ class Agent(AbstractAgent):
         It can be any function registered with
         :py:func:`~muse.hooks.register_initial_asset_transform`.
         """
-        if merge_transform is None:
-            merge_transform = asset_merge_factory()
-        self.merge_transform = merge_transform
+        if housekeeping is None:
+            housekeeping = housekeeping_factory()
+        self._housekeeping = housekeeping
+
         """Transforms applied on the old and new assets.
 
         It could mean using only the new assets, or merging old and new, etc...
         It can be any function registered with
         :py:func:`~muse.hooks.register_final_asset_transform`.
         """
-        self.demand_threshold = demand_threshold
+        if merge_transform is None:
+            merge_transform = asset_merge_factory()
+        self.merge_transform = merge_transform
+
         """Threshold below which the demand share is zero.
 
         This criteria avoids fulfilling demand for very small values. If None,
         then the criteria is not applied.
         """
-        self.asset_threshold = asset_threshold
+        self.demand_threshold = demand_threshold
+
         """Threshold below which assets are not added."""
+        self.asset_threshold = asset_threshold
 
     @property
     def forecast_year(self):
@@ -301,8 +319,9 @@ class InvestingAgent(Agent):
 
         from muse.utilities import reduce_assets
 
-        assert "year" not in technologies.dims
+        # Check inputs
         assert len(market.year) == 2
+        assert "year" not in technologies.dims
         assert "year" not in demand.dims
 
         # Time period

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -349,7 +349,7 @@ def max_capacity_expansion(
     forecasted = capacity.isel(year=1, drop=True)
 
     # Max capacity addition constraint
-    time_frame = capacity.year[1] - capacity.year[0]
+    time_frame = int(capacity.year[1] - capacity.year[0])
     add_cap = techs.max_capacity_addition * time_frame
 
     # Total capacity limit constraint

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -176,7 +176,7 @@ def register_constraints(function: CONSTRAINT_SIGNATURE) -> CONSTRAINT_SIGNATURE
         """Computes and standardizes a constraint."""
         # Check inputs
         assert "year" not in technologies.dims
-        assert len(capacity.year) == 2
+        assert len(capacity.year) == 2  # current year and investment year
 
         # Calculate constraint
         constraint = function(  # type: ignore
@@ -879,13 +879,13 @@ def lp_constraint_matrix(
          >>> from muse.utilities import reduce_assets
          >>> res = examples.sector("residential", model="medium")
          >>> market = examples.residential_market("medium")
-         >>> technologies = res.technologies.sel(year=market.year.min() + 5)
+         >>> technologies = res.technologies.sel(year=2025)
          >>> search = examples.search_space("residential", model="medium")
          >>> assets = next(a.assets for a in res.agents)
          >>> capacity = reduce_assets(assets.capacity, coords=("region", "technology"))
          >>> demand = None # not used in max production
-         >>> constraint = cs.max_production(demand, capacity, search,
-         ...                                technologies) # noqa: E501
+         >>> constraint = cs.max_production(demand, capacity.sel(year=[2020, 2025]),
+         ...                                search, technologies) # noqa: E501
          >>> lpcosts = cs.lp_costs(
          ...     (
          ...         technologies
@@ -1015,17 +1015,17 @@ class ScipyAdapter:
         >>> from muse import constraints as cs
         >>> res = examples.sector("residential", model="medium")
         >>> market = examples.residential_market("medium")
-        >>> technologies = res.technologies.sel(year=market.year.min() + 5)
+        >>> technologies = res.technologies.sel(year=2025)
         >>> search = examples.search_space("residential", model="medium")
         >>> assets = next(a.assets for a in res.agents)
         >>> capacity = reduce_assets(assets.capacity, coords=("region", "technology"))
-        >>> market_demand =  0.8 * maximum_production(
+        >>> market_demand = 0.8 * maximum_production(
         ...     technologies,
         ...     assets.capacity.sel(year=2025).groupby("technology").sum("asset"),
         ... ).rename(technology="asset")
         >>> costs = search * np.arange(np.prod(search.shape)).reshape(search.shape)
         >>> constraint = cs.max_capacity_expansion(
-        ...     market_demand, capacity, search, technologies)
+        ...     market_demand, capacity.sel(year=[2020, 2025]), search, technologies)
 
         The constraint acts over capacity decision variables only:
 

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -176,6 +176,7 @@ def register_constraints(function: CONSTRAINT_SIGNATURE) -> CONSTRAINT_SIGNATURE
         """Computes and standardizes a constraint."""
         # Check inputs
         assert "year" not in technologies.dims
+        assert len(capacity.year) == 2
 
         # Calculate constraint
         constraint = function(  # type: ignore

--- a/src/muse/demand_share.py
+++ b/src/muse/demand_share.py
@@ -110,9 +110,10 @@ def factory(
             ["commodity", "year", "timeslice", "region"],
             optional=["dst_region"],
         )
+        assert len(market.year) == 2
         check_dimensions(
             technologies,
-            ["technology", "year", "region"],
+            ["technology", "region"],
             optional=["timeslice", "commodity", "dst_region"],
         )
 

--- a/src/muse/mca.py
+++ b/src/muse/mca.py
@@ -185,25 +185,20 @@ class MCA:
     def find_equilibrium(
         self,
         market: Dataset,
-        sectors: list[AbstractSector] | None = None,
-        maxiter: int | None = None,
     ) -> FindEquilibriumResults:
         """Specialised version of the find_equilibrium function.
 
         Arguments:
             market: Commodities market, with the prices, supply, consumption and demand.
-            sectors: A list of the sectors participating in the simulation.
-            maxiter: Maximum number of iterations.
 
         Returns:
             A tuple with the updated market (prices, supply, consumption and demand) and
             sector.
         """
-        maxiter = self.maximum_iterations if not maxiter else maxiter
         return find_equilibrium(
             market=market,
-            sectors=self.sectors if sectors is None else sectors,
-            maxiter=maxiter,
+            sectors=self.sectors,
+            maxiter=self.maximum_iterations,
             tol=self.tolerance,
             equilibrium_variable=self.equilibrium_variable,
             tol_unmet_demand=self.tolerance_unmet_demand,

--- a/src/muse/sectors/sector.py
+++ b/src/muse/sectors/sector.py
@@ -198,8 +198,10 @@ class Sector(AbstractSector):  # type: ignore
         def group_assets(x: xr.DataArray) -> xr.DataArray:
             return xr.Dataset(dict(x=x)).groupby("region").sum("asset").x
 
-        time_period = int(mca_market.year.max() - mca_market.year.min())
-        current_year = int(mca_market.year.min())
+        # Time period from the market object
+        assert len(mca_market.year) == 2
+        current_year = int(mca_market.year[0])
+        investment_year = int(mca_market.year[1])
         getLogger(__name__).info(f"Running {self.name} for year {current_year}")
 
         # Agent interactions
@@ -214,12 +216,11 @@ class Sector(AbstractSector):  # type: ignore
         )
 
         # Investments
+        # uses technology data from the investment year
         for subsector in self.subsectors:
             subsector.invest(
-                self.technologies,
-                market,
-                time_period=time_period,
-                current_year=current_year,
+                technologies=self.technologies.sel(year=investment_year),
+                market=market,
             )
 
         # Full output data

--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -52,9 +52,10 @@ class Subsector:
         self,
         technologies: xr.Dataset,
         market: xr.Dataset,
-        time_period: int,
-        current_year: int,
     ) -> None:
+        assert "year" not in technologies.dims
+        assert len(market.year) == 2
+
         # Expand prices to include destination region (for trade models)
         if self.expand_market_prices:
             market = market.copy()
@@ -67,15 +68,17 @@ class Subsector:
             agent.asset_housekeeping()
 
         # Perform the investments
-        self.aggregate_lp(technologies, market, time_period, current_year=current_year)
+        self.aggregate_lp(technologies, market)
 
     def aggregate_lp(
         self,
         technologies: xr.Dataset,
         market: xr.Dataset,
-        time_period,
-        current_year,
     ) -> None:
+        assert "year" not in technologies.dims
+        assert len(market.year) == 2
+        current_year = int(market.year[0])
+
         # Split demand across agents
         demands = self.demand_share(
             self.agents,
@@ -100,7 +103,7 @@ class Subsector:
                 share = demands.sel(asset=demands.agent == agent.uuid)
             else:
                 share = demands
-            agent.next(technologies, market, share, time_period=time_period)
+            agent.next(technologies=technologies, market=market, demand=share)
 
     @classmethod
     def factory(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -143,7 +143,8 @@ def test_run_retro_agent(retro_agent, technologies, agent_market, demand_share):
     technologies.max_capacity_addition[:] = retro_agent.assets.capacity.sum() * 100
     technologies.max_capacity_growth[:] = retro_agent.assets.capacity.sum() * 100
 
-    retro_agent.next(technologies, agent_market, demand_share, time_period=5)
+    investment_year = int(agent_market.year[1])
+    retro_agent.next(technologies.sel(year=investment_year), agent_market, demand_share)
 
 
 def test_merge_assets(assets):

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -425,7 +425,6 @@ def test_scipy_solver(technologies, costs, constraints):
         search_space=xr.ones_like(costs),
         technologies=technologies,
         constraints=constraints,
-        year=2025,
     )
     assert isinstance(solution, xr.DataArray)
     assert set(solution.dims) == {"asset", "replacement"}

--- a/tests/test_subsector.py
+++ b/tests/test_subsector.py
@@ -47,7 +47,7 @@ def test_subsector_investing_aggregation():
             subsector = Subsector(agents, commodities)
             initial_agents = deepcopy(agents)
             assert {agent.year for agent in agents} == {int(market.year.min())}
-            subsector.aggregate_lp(technologies, market, time_period=5, current_year=5)
+            subsector.aggregate_lp(technologies.sel(year=2020), market)
             assert {agent.year for agent in agents} == {int(market.year.min() + 5)}
             for initial, final in zip(initial_agents, agents):
                 assert initial.assets.sum() != final.assets.sum()
@@ -104,7 +104,7 @@ def test_subsector_noninvesting_aggregation(market, model, technologies, tmp_pat
         commodity=technologies.commodity, region=technologies.region
     ).interp(year=[2020, 2025])
     assert all(agent.year == 2020 for agent in agents)
-    subsector.aggregate_lp(technologies, market, time_period=5, current_year=2020)
+    subsector.aggregate_lp(technologies.sel(year=2020), market)
 
 
 def test_factory_smoke_test(model, technologies, tmp_path):

--- a/tests/test_trade.py
+++ b/tests/test_trade.py
@@ -17,11 +17,11 @@ def constraints_args(sector="power", model="trade") -> Mapping[str, Any]:
     assets = agent_concatenation({u.uuid: u.assets for u in list(power.agents)})
     capacity = reduce_assets(assets.capacity, coords=("region", "technology"))
     return dict(
-        demand=market.consumption.sel(year=market.year.min(), drop=True),
-        capacity=capacity,
+        demand=market.consumption.sel(year=2025, drop=True),
+        capacity=capacity.sel(year=[2020, 2025]),
         search_space=search_space,
         market=market,
-        technologies=power.technologies.sel(year=market.year.min(), drop=True),
+        technologies=power.technologies.sel(year=2025, drop=True),
     )
 
 

--- a/tests/test_trade.py
+++ b/tests/test_trade.py
@@ -123,7 +123,7 @@ def test_power_sector_no_investment():
     from muse.utilities import agent_concatenation
 
     power = examples.sector("power", "trade")
-    market = examples.matching_market("power", "trade").sel(year=[2020, 2025, 2030])
+    market = examples.matching_market("power", "trade").sel(year=[2020, 2025])
 
     initial = agent_concatenation({u.uuid: u.assets.capacity for u in power.agents})
     power.next(market)
@@ -137,12 +137,12 @@ def test_power_sector_some_investment():
     from muse.utilities import agent_concatenation
 
     power = examples.sector("power", "trade")
-    market = examples.matching_market("power", "trade").sel(year=[2020, 2025, 2030])
+    market = examples.matching_market("power", "trade").sel(year=[2020, 2025])
     market.consumption[:] *= 1.5
 
     initial = agent_concatenation({u.uuid: u.assets.capacity for u in power.agents})
     result = power.next(market)
     final = agent_concatenation({u.uuid: u.assets.capacity for u in power.agents})
     assert "windturbine" not in initial.technology
-    assert final.sel(asset=final.technology == "windturbine", year=2030).sum() < 1
+    assert final.sel(asset=final.technology == "windturbine", year=2025).sum() < 1
     assert "dst_region" not in result.dims


### PR DESCRIPTION
This is just a refactoring change. There are many places in the code where "year" is passed around as an argument, often for the purposes of filtering the technologies dataset. We now do this filtering early on and just pass around the filtered object, so we can get rid of the need for a year argument in many places. Where year is required, it can be extracted from the `market` object. There are checks in place to make sure everything is consistent.