### PR TITLE
Switch to modern annotation style in all files

### DIFF
--- a/src/muse/__init__.py
+++ b/src/muse/__init__.py
@@ -1,5 +1,7 @@
 """MUSE model."""
 
+from __future__ import annotations
+
 import os
 from contextlib import suppress
 from importlib.metadata import PackageNotFoundError, version

--- a/src/muse/__main__.py
+++ b/src/muse/__main__.py
@@ -1,5 +1,7 @@
 """Makes MUSE executable."""
 
+from __future__ import annotations
+
 import pathlib
 from argparse import ArgumentParser
 

--- a/src/muse/agents/agent.py
+++ b/src/muse/agents/agent.py
@@ -1,8 +1,10 @@
 """Holds all building agents."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Callable, Optional, Union
+from typing import Callable
 
 import xarray as xr
 
@@ -19,11 +21,11 @@ class AbstractAgent(ABC):
         self,
         name: str = "Agent",
         region: str = "",
-        assets: Optional[xr.Dataset] = None,
+        assets: xr.Dataset | None = None,
         interpolation: str = "linear",
-        category: Optional[str] = None,
-        quantity: Optional[float] = 1,
-        timeslice_level: Optional[str] = None,
+        category: str | None = None,
+        quantity: float | None = 1,
+        timeslice_level: str | None = None,
     ):
         """Creates a standard MUSE agent.
 
@@ -66,10 +68,10 @@ class AbstractAgent(ABC):
 
     def filter_input(
         self,
-        dataset: Union[xr.Dataset, xr.DataArray],
-        year: Optional[Union[Sequence[int], int]] = None,
+        dataset: xr.Dataset | xr.DataArray,
+        year: Sequence[int] | int | None = None,
         **kwargs,
-    ) -> Union[xr.Dataset, xr.DataArray]:
+    ) -> xr.Dataset | xr.DataArray:
         """Filter inputs for usage in agent.
 
         For instance, filters down to agent's region, etc.
@@ -113,22 +115,22 @@ class Agent(AbstractAgent):
         self,
         name: str = "Agent",
         region: str = "USA",
-        assets: Optional[xr.Dataset] = None,
+        assets: xr.Dataset | None = None,
         interpolation: str = "linear",
-        search_rules: Optional[Callable] = None,
-        objectives: Optional[Callable] = None,
-        decision: Optional[Callable] = None,
+        search_rules: Callable | None = None,
+        objectives: Callable | None = None,
+        decision: Callable | None = None,
         year: int = 2010,
         maturity_threshold: float = 0,
         forecast: int = 5,
-        housekeeping: Optional[Callable] = None,
-        merge_transform: Optional[Callable] = None,
-        demand_threshold: Optional[float] = None,
-        category: Optional[str] = None,
+        housekeeping: Callable | None = None,
+        merge_transform: Callable | None = None,
+        demand_threshold: float | None = None,
+        category: str | None = None,
         asset_threshold: float = 1e-4,
-        quantity: Optional[float] = 1,
+        quantity: float | None = 1,
         spend_limit: int = 0,
-        timeslice_level: Optional[str] = None,
+        timeslice_level: str | None = None,
         **kwargs,
     ):
         """Creates a standard agent.
@@ -278,8 +280,8 @@ class InvestingAgent(Agent):
     def __init__(
         self,
         *args,
-        constraints: Optional[Callable] = None,
-        investment: Optional[Callable] = None,
+        constraints: Callable | None = None,
+        investment: Callable | None = None,
         **kwargs,
     ):
         """Creates an investing agent.
@@ -465,7 +467,7 @@ class InvestingAgent(Agent):
         technologies: xr.Dataset,
         investments: xr.DataArray,
         investment_year: int,
-    ) -> Optional[xr.DataArray]:
+    ) -> xr.DataArray | None:
         from muse.investments import cliff_retirement_profile
 
         assert "year" not in technologies.dims

--- a/src/muse/agents/factories.py
+++ b/src/muse/agents/factories.py
@@ -1,8 +1,10 @@
 """Holds all building agents."""
 
+from __future__ import annotations
+
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 
 import xarray as xr
 
@@ -15,7 +17,7 @@ def create_standard_agent(
     capacity: xr.DataArray,
     year: int,
     region: str,
-    share: Optional[str] = None,
+    share: str | None = None,
     interpolation: str = "linear",
     **kwargs,
 ):
@@ -50,7 +52,7 @@ def create_retrofit_agent(
     year: int,
     region: str,
     interpolation: str = "linear",
-    decision: Union[Callable, str, Mapping] = "mean",
+    decision: Callable | str | Mapping = "mean",
     **kwargs,
 ):
     """Creates retrofit agent from muse primitives."""
@@ -93,11 +95,11 @@ def create_newcapa_agent(
     year: int,
     region: str,
     share: str,
-    search_rules: Union[str, Sequence[str]] = "all",
+    search_rules: str | Sequence[str] = "all",
     interpolation: str = "linear",
-    merge_transform: Union[str, Mapping, Callable] = "new",
+    merge_transform: str | Mapping | Callable = "new",
     quantity: float = 0.3,
-    housekeeping: Union[str, Mapping, Callable] = "noop",
+    housekeeping: str | Mapping | Callable = "noop",
     retrofit_present: bool = True,
     **kwargs,
 ):
@@ -173,11 +175,11 @@ def create_agent(agent_type: str, **kwargs) -> Agent:
 
 
 def agents_factory(
-    params_or_path: Union[str, Path, list],
-    capacity: Union[xr.DataArray, str, Path],
+    params_or_path: str | Path | list,
+    capacity: xr.DataArray | str | Path,
     technologies: xr.Dataset,
-    regions: Optional[Sequence[str]] = None,
-    year: Optional[int] = None,
+    regions: Sequence[str] | None = None,
+    year: int | None = None,
     **kwargs,
 ) -> list[Agent]:
     """Creates a list of agents for the chosen sector."""
@@ -273,12 +275,10 @@ def _shared_capacity(
 
 
 def _standardize_inputs(
-    housekeeping: Union[str, Mapping, Callable] = "clean",
-    merge_transform: Union[str, Mapping, Callable] = "merge",
-    objectives: Union[
-        Callable, str, Mapping, Sequence[Union[str, Mapping]]
-    ] = "fixed_costs",
-    decision: Union[Callable, str, Mapping] = "mean",
+    housekeeping: str | Mapping | Callable = "clean",
+    merge_transform: str | Mapping | Callable = "merge",
+    objectives: Callable | str | Mapping | Sequence[str | Mapping] = "fixed_costs",
+    decision: Callable | str | Mapping = "mean",
     **kwargs,
 ):
     from muse.decisions import factory as decision_factory
@@ -302,11 +302,9 @@ def _standardize_inputs(
 
 
 def _standardize_investing_inputs(
-    search_rules: Optional[Union[str, Sequence[str]]] = None,
-    investment: Union[Callable, str, Mapping] = "scipy",
-    constraints: Optional[
-        Union[Callable, str, Mapping, Sequence[Union[str, Mapping]]]
-    ] = None,
+    search_rules: str | Sequence[str] | None = None,
+    investment: Callable | str | Mapping = "scipy",
+    constraints: Callable | str | Mapping | Sequence[str | Mapping] | None = None,
     **kwargs,
 ) -> dict[str, Any]:
     from muse.constraints import factory as constraints_factory

--- a/src/muse/carbon_budget.py
+++ b/src/muse/carbon_budget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import MutableMapping, Sequence
 from typing import Callable
 

--- a/src/muse/commodities.py
+++ b/src/muse/commodities.py
@@ -1,8 +1,9 @@
 """Methods and types around commodities."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from enum import IntFlag, auto
-from typing import Union
 
 from numpy import ndarray
 from xarray import DataArray, Dataset
@@ -117,7 +118,7 @@ class CommodityUsage(IntFlag):
 
 def check_usage(
     data: Sequence[CommodityUsage],
-    flag: Union[str, CommodityUsage, None],
+    flag: str | CommodityUsage | None,
     match: str = "all",
 ) -> ndarray:
     """Match usage flags with input data array.

--- a/src/muse/decisions.py
+++ b/src/muse/decisions.py
@@ -26,6 +26,8 @@ Returns:
     A data array with ranked replacement technologies.
 """
 
+from __future__ import annotations
+
 __all__ = [
     "epsilon_constraints",
     "factory",
@@ -37,12 +39,11 @@ __all__ = [
     "single_objective",
     "weighted_sum",
 ]
+
 from collections.abc import Mapping, MutableMapping, Sequence
 from typing import (
     Any,
     Callable,
-    Optional,
-    Union,
 )
 
 from xarray import DataArray, Dataset
@@ -96,7 +97,7 @@ def coeff_sign(minimise: bool, coeff: Any):
     return coeff if minimise else -coeff
 
 
-def factory(settings: Union[str, Mapping] = "mean") -> Callable:
+def factory(settings: str | Mapping = "mean") -> Callable:
     """Creates a decision method based on the input settings."""
     if isinstance(settings, str):
         function = DECISIONS[settings]
@@ -169,7 +170,7 @@ def weighted_sum(objectives: Dataset, parameters: Mapping[str, float]) -> DataAr
 
 @register_decision(name="lexo")
 def lexical_comparison(
-    objectives: Dataset, parameters: Union[PARAMS_TYPE, Sequence[tuple[str, float]]]
+    objectives: Dataset, parameters: PARAMS_TYPE | Sequence[tuple[str, float]]
 ) -> DataArray:
     """Lexical comparison over the objectives.
 
@@ -202,7 +203,7 @@ def lexical_comparison(
 
 @register_decision(name="retro_lexo")
 def retro_lexical_comparison(
-    objectives: Dataset, parameters: Union[PARAMS_TYPE, Sequence[tuple[str, float]]]
+    objectives: Dataset, parameters: PARAMS_TYPE | Sequence[tuple[str, float]]
 ) -> DataArray:
     """Lexical comparison over the objectives.
 
@@ -231,7 +232,7 @@ def retro_lexical_comparison(
 
 
 def _epsilon_constraints(
-    objectives: Dataset, optimize: str, mask: Optional[Any] = None, **epsilons
+    objectives: Dataset, optimize: str, mask: Any | None = None, **epsilons
 ) -> DataArray:
     """Minimizes one objective subject to constraints on other objectives."""
     constraints = True
@@ -247,8 +248,8 @@ def _epsilon_constraints(
 @register_decision(name=("epsilon", "epsilon_con"))
 def epsilon_constraints(
     objectives: Dataset,
-    parameters: Union[PARAMS_TYPE, Sequence[tuple[str, bool, float]]],
-    mask: Optional[Any] = None,
+    parameters: PARAMS_TYPE | Sequence[tuple[str, bool, float]],
+    mask: Any | None = None,
 ) -> DataArray:
     r"""Minimizes first objective subject to constraints on other objectives.
 
@@ -310,7 +311,7 @@ def retro_epsilon_constraints(
 @register_decision(name=("single", "singleObj"))
 def single_objective(
     objectives: Dataset,
-    parameters: Union[str, tuple[str, bool], tuple[str, bool, float], PARAMS_TYPE],
+    parameters: str | tuple[str, bool] | tuple[str, bool, float] | PARAMS_TYPE,
 ) -> DataArray:
     """Single objective decision method.
 

--- a/src/muse/decorators.py
+++ b/src/muse/decorators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from logging import getLogger
 from typing import Callable

--- a/src/muse/demand_matching.py
+++ b/src/muse/demand_matching.py
@@ -43,10 +43,10 @@ on production :math:`\sum_d X_{d, i} \leq M_i`. The algorithms in this module tr
 solve these constrained problems one way or another.
 """
 
+from __future__ import annotations
+
 __all__ = ["demand_matching"]
 
-
-from typing import Optional
 
 import pandas as pd
 from xarray import DataArray
@@ -58,7 +58,7 @@ def demand_matching(
     demand: DataArray,
     cost: DataArray,
     *constraints: DataArray,
-    protected_dims: Optional[set] = None,
+    protected_dims: set | None = None,
 ) -> DataArray:
     r"""Demand matching over heterogeneous dimensions.
 

--- a/src/muse/demand_share.py
+++ b/src/muse/demand_share.py
@@ -37,6 +37,8 @@ Returns:
     only service that par of the demand.
 """
 
+from __future__ import annotations
+
 __all__ = [
     "DEMAND_SHARE_SIGNATURE",
     "factory",
@@ -45,12 +47,11 @@ __all__ = [
     "unmet_demand",
     "unmet_forecasted_demand",
 ]
+
 from collections.abc import Hashable, Mapping, MutableMapping, Sequence
 from typing import (
     Any,
     Callable,
-    Optional,
-    Union,
     cast,
 )
 
@@ -81,7 +82,7 @@ def register_demand_share(function: DEMAND_SHARE_SIGNATURE):
 
 
 def factory(
-    settings: Optional[Union[str, Mapping[str, Any]]] = None,
+    settings: str | Mapping[str, Any] | None = None,
 ) -> DEMAND_SHARE_SIGNATURE:
     if settings is None or isinstance(settings, str):
         name = settings or "standard_demand"
@@ -136,7 +137,7 @@ def new_and_retro(
     technologies: xr.Dataset,
     current_year: int,
     forecast: int,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     r"""Splits demand across new and retro agents.
 
@@ -352,7 +353,7 @@ def standard_demand(
     technologies: xr.Dataset,
     current_year: int,
     forecast: int,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     r"""Splits demand across new agents.
 
@@ -463,7 +464,7 @@ def unmet_forecasted_demand(
     technologies: xr.Dataset,
     current_year: int,
     forecast: int,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     """Forecast demand that cannot be serviced by non-decommissioned current assets."""
     from muse.commodities import is_enduse
@@ -538,7 +539,7 @@ def unmet_demand(
     market: xr.Dataset,
     capacity: xr.DataArray,
     technologies: xr.Dataset,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ):
     r"""Share of the demand that cannot be serviced by the existing assets.
 
@@ -578,7 +579,7 @@ def new_consumption(
     technologies: xr.Dataset,
     current_year: int,
     forecast: int,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     r"""Computes share of the demand attributed to new agents.
 
@@ -619,7 +620,7 @@ def new_and_retro_demands(
     technologies: xr.Dataset,
     current_year: int,
     forecast: int,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.Dataset:
     """Splits demand into *new* and *retrofit* demand.
 

--- a/src/muse/examples.py
+++ b/src/muse/examples.py
@@ -25,9 +25,11 @@ The same models can be instantiated in a python script as follows:
     model.run()
 """
 
+from __future__ import annotations
+
 from logging import getLogger
 from pathlib import Path
-from typing import Optional, Union, cast
+from typing import cast
 
 import numpy as np
 import xarray as xr
@@ -81,7 +83,7 @@ def model(name: str = "default", test: bool = False) -> MCA:
 
 def copy_model(
     name: str = "default",
-    path: Optional[Union[str, Path]] = None,
+    path: str | Path | None = None,
     overwrite: bool = False,
 ) -> Path:
     """Copy model files to given path.

--- a/src/muse/filters.py
+++ b/src/muse/filters.py
@@ -73,6 +73,8 @@ Returns:
     An initial search space
 """
 
+from __future__ import annotations
+
 __all__ = [
     "compress",
     "currently_existing_tech",
@@ -94,8 +96,6 @@ from collections.abc import Mapping, MutableMapping, Sequence
 from typing import (
     Any,
     Callable,
-    Optional,
-    Union,
     cast,
 )
 
@@ -162,7 +162,7 @@ def register_initializer(function: SSI_SIGNATURE) -> Callable:
 
 
 def factory(
-    settings: Optional[Union[str, Mapping, Sequence[Union[str, Mapping]]]] = None,
+    settings: str | Mapping | Sequence[str | Mapping] | None = None,
     separator: str = "->",
 ):
     """Creates filters from input TOML data.

--- a/src/muse/hooks.py
+++ b/src/muse/hooks.py
@@ -1,5 +1,7 @@
 """Pre and post hooks on agents."""
 
+from __future__ import annotations
+
 __all__ = [
     "asset_merge_factory",
     "clean",
@@ -11,8 +13,9 @@ __all__ = [
     "register_final_asset_transform",
     "register_initial_asset_transform",
 ]
+
 from collections.abc import Mapping, MutableMapping
-from typing import Callable, Union
+from typing import Callable
 
 from xarray import Dataset
 
@@ -25,7 +28,7 @@ FINAL_ASSET_TRANSFORM: MutableMapping[str, Callable] = {}
 """ Transform at the end of each step, including new assets. """
 
 
-def housekeeping_factory(settings: Union[str, Mapping] = "noop") -> Callable:
+def housekeeping_factory(settings: str | Mapping = "noop") -> Callable:
     """Returns a function for performing initial housekeeping.
 
     For instance, remove technologies with no capacity now or in the future.
@@ -49,7 +52,7 @@ def housekeeping_factory(settings: Union[str, Mapping] = "noop") -> Callable:
     return initial_assets_transform
 
 
-def asset_merge_factory(settings: Union[str, Mapping] = "new") -> Callable:
+def asset_merge_factory(settings: str | Mapping = "new") -> Callable:
     """Returns a function for merging new investments into assets.
 
     Available merging functions should be registered with

--- a/src/muse/interactions.py
+++ b/src/muse/interactions.py
@@ -14,6 +14,8 @@ interaction. The second registrator registers the interaction proper: it takes a
 arguments and returns nothing. It is expected to modify the agents in-place.
 """
 
+from __future__ import annotations
+
 __all__ = [
     "factory",
     "new_to_retro_net",
@@ -23,7 +25,7 @@ __all__ = [
 ]
 
 from collections.abc import Mapping, Sequence
-from typing import Callable, Optional, Union
+from typing import Callable
 
 from muse.agents import AbstractAgent, Agent
 from muse.errors import NoInteractionsFound
@@ -87,7 +89,7 @@ def register_agent_interaction(function: AGENT_INTERACTION_SIGNATURE):
 
 
 def factory(
-    inputs: Optional[Sequence[Union[Mapping, tuple[str, str]]]] = None,
+    inputs: Sequence[Mapping | tuple[str, str]] | None = None,
 ) -> Callable[[Sequence[AbstractAgent]], None]:
     """Creates an interaction functor."""
     if inputs is None:

--- a/src/muse/investments.py
+++ b/src/muse/investments.py
@@ -39,17 +39,19 @@ Returns:
     of newly invested capacity.
 """
 
+from __future__ import annotations
+
 __all__ = [
     "INVESTMENT_SIGNATURE",
     "adhoc_match_demand",
     "cliff_retirement_profile",
     "register_investment",
 ]
+
 from collections.abc import Mapping, MutableMapping
 from typing import (
     Any,
     Callable,
-    Optional,
     Union,
     cast,
 )
@@ -109,7 +111,7 @@ def register_investment(function: INVESTMENT_SIGNATURE) -> INVESTMENT_SIGNATURE:
     return decorated
 
 
-def factory(settings: Optional[Union[str, Mapping]] = None) -> Callable:
+def factory(settings: str | Mapping | None = None) -> Callable:
     if settings is None:
         name = "match_demand"
         params: dict = {}
@@ -219,7 +221,7 @@ def adhoc_match_demand(
     search_space: xr.DataArray,
     technologies: xr.Dataset,
     constraints: list[Constraint],
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     from muse.demand_matching import demand_matching
     from muse.quantities import capacity_in_use, maximum_production
@@ -269,7 +271,7 @@ def scipy_match_demand(
     search_space: xr.DataArray,
     technologies: xr.Dataset,
     constraints: list[Constraint],
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     from logging import getLogger
 

--- a/src/muse/objectives.py
+++ b/src/muse/objectives.py
@@ -46,6 +46,8 @@ Returns:
     A `timeslice` dimension may also be present.
 """
 
+from __future__ import annotations
+
 __all__ = [
     "capacity_to_service_demand",
     "capital_costs",
@@ -62,7 +64,7 @@ __all__ = [
 ]
 
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Union
 
 import numpy as np
 import xarray as xr
@@ -95,7 +97,7 @@ def objective_factory(settings=Union[str, Mapping]):
 
 
 def factory(
-    settings: Union[str, Mapping, Sequence[Union[str, Mapping]]] = "LCOE",
+    settings: str | Mapping | Sequence[str | Mapping] = "LCOE",
 ) -> Callable:
     """Creates a function computing multiple objectives.
 
@@ -129,7 +131,7 @@ def factory(
         technologies: xr.Dataset,
         demand: xr.DataArray,
         prices: xr.DataArray,
-        timeslice_level: Optional[str] = None,
+        timeslice_level: str | None = None,
         *args,
         **kwargs,
     ) -> xr.Dataset:
@@ -257,7 +259,7 @@ def consumption(
     technologies: xr.Dataset,
     demand: xr.DataArray,
     prices: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
     *args,
     **kwargs,
 ) -> xr.DataArray:
@@ -337,7 +339,7 @@ def emission_cost(
     technologies: xr.Dataset,
     demand: xr.DataArray,
     prices: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
     *args,
     **kwargs,
 ) -> xr.DataArray:
@@ -370,7 +372,7 @@ def fuel_consumption_cost(
     technologies: xr.Dataset,
     demand: xr.DataArray,
     prices: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
     *args,
     **kwargs,
 ):
@@ -400,7 +402,7 @@ def annual_levelized_cost_of_energy(
     technologies: xr.Dataset,
     demand: xr.DataArray,
     prices: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
     *args,
     **kwargs,
 ):
@@ -446,7 +448,7 @@ def lifetime_levelized_cost_of_energy(
     technologies: xr.Dataset,
     demand: xr.DataArray,
     prices: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
     *args,
     **kwargs,
 ):
@@ -493,7 +495,7 @@ def net_present_value(
     technologies: xr.Dataset,
     demand: xr.DataArray,
     prices: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
     *args,
     **kwargs,
 ):
@@ -533,7 +535,7 @@ def net_present_cost(
     technologies: xr.Dataset,
     demand: xr.DataArray,
     prices: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
     *args,
     **kwargs,
 ):
@@ -572,7 +574,7 @@ def equivalent_annual_cost(
     technologies: xr.Dataset,
     demand: xr.DataArray,
     prices: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
     *args,
     **kwargs,
 ):

--- a/src/muse/outputs/mca.py
+++ b/src/muse/outputs/mca.py
@@ -16,13 +16,14 @@ The function should never modify it's arguments. It can return either a pandas d
 or an xarray xr.DataArray.
 """
 
+from __future__ import annotations
+
 from collections.abc import Mapping, MutableMapping
 from operator import attrgetter
 from pathlib import Path
 from typing import (
     Any,
     Callable,
-    Optional,
     Union,
     cast,
 )
@@ -52,7 +53,7 @@ OUTPUTS_PARAMETERS = Union[str, Mapping]
 
 @registrator(registry=OUTPUT_QUANTITIES)
 def register_output_quantity(
-    function: Optional[OUTPUT_QUANTITY_SIGNATURE] = None,
+    function: OUTPUT_QUANTITY_SIGNATURE | None = None,
 ) -> Callable:
     """Registers a function to compute an output quantity."""
     from functools import wraps

--- a/src/muse/outputs/sector.py
+++ b/src/muse/outputs/sector.py
@@ -19,8 +19,10 @@ technologies in the market. It returns a single xr.DataArray object.
 The function should never modify it's arguments.
 """
 
+from __future__ import annotations
+
 from collections.abc import Mapping, MutableMapping
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Union
 
 import pandas as pd
 import xarray as xr
@@ -100,7 +102,7 @@ def _factory(
     quantities = [_quantity_factory(param, registry) for param in params]
     sinks = [sink_factory(param, sector_name=sector_name) for param in params]
 
-    def save_multiple_outputs(market, *args, year: Optional[int] = None) -> list[Any]:
+    def save_multiple_outputs(market, *args, year: int | None = None) -> list[Any]:
         if year is None:
             year = int(market.year.min())
 
@@ -151,8 +153,8 @@ def capacity(
 
 def market_quantity(
     quantity: xr.DataArray,
-    sum_over: Optional[Union[str, list[str]]] = None,
-    drop: Optional[Union[str, list[str]]] = None,
+    sum_over: str | list[str] | None = None,
+    drop: str | list[str] | None = None,
 ) -> xr.DataArray:
     from pandas import MultiIndex
 
@@ -177,8 +179,8 @@ def market_quantity(
 def consumption(
     market: xr.Dataset,
     capacity: xr.DataArray,
-    sum_over: Optional[list[str]] = None,
-    drop: Optional[list[str]] = None,
+    sum_over: list[str] | None = None,
+    drop: list[str] | None = None,
     rounding: int = 4,
 ) -> xr.DataArray:
     """Current consumption."""
@@ -197,8 +199,8 @@ def consumption(
 def supply(
     market: xr.Dataset,
     capacity: xr.DataArray,
-    sum_over: Optional[list[str]] = None,
-    drop: Optional[list[str]] = None,
+    sum_over: list[str] | None = None,
+    drop: list[str] | None = None,
     rounding: int = 4,
 ) -> xr.DataArray:
     """Current supply."""
@@ -217,8 +219,8 @@ def supply(
 def costs(
     market: xr.Dataset,
     capacity: xr.DataArray,
-    sum_over: Optional[list[str]] = None,
-    drop: Optional[list[str]] = None,
+    sum_over: list[str] | None = None,
+    drop: list[str] | None = None,
     rounding: int = 4,
 ) -> xr.DataArray:
     """Current costs."""

--- a/src/muse/production.py
+++ b/src/muse/production.py
@@ -30,6 +30,8 @@ Returns:
     A `xr.DataArray` with the amount produced for each good from each asset.
 """
 
+from __future__ import annotations
+
 __all__ = [
     "PRODUCTION_SIGNATURE",
     "factory",
@@ -37,8 +39,9 @@ __all__ = [
     "register_production",
     "supply",
 ]
+
 from collections.abc import Mapping, MutableMapping
-from typing import Any, Callable, Optional, Union, cast
+from typing import Any, Callable, cast
 
 import xarray as xr
 
@@ -63,7 +66,7 @@ def register_production(function: PRODUCTION_SIGNATURE = None):
 
 
 def factory(
-    settings: Union[str, Mapping] = "maximum_production", **kwargs
+    settings: str | Mapping = "maximum_production", **kwargs
 ) -> PRODUCTION_SIGNATURE:
     """Creates a production functor.
 
@@ -101,7 +104,7 @@ def maximum_production(
     market: xr.Dataset,
     capacity: xr.DataArray,
     technologies: xr.Dataset,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     """Production when running at full capacity.
 
@@ -118,7 +121,7 @@ def supply(
     market: xr.Dataset,
     capacity: xr.DataArray,
     technologies: xr.Dataset,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     """Service current demand equally from all assets.
 

--- a/src/muse/quantities.py
+++ b/src/muse/quantities.py
@@ -7,8 +7,10 @@ functions are used in different areas of the model.
 Functions for calculating costs (e.g. LCOE, EAC) are in the `costs` module.
 """
 
+from __future__ import annotations
+
 from collections.abc import Sequence
-from typing import Optional, Union, cast
+from typing import cast
 
 import numpy as np
 import xarray as xr
@@ -19,8 +21,8 @@ from muse.timeslices import broadcast_timeslice, distribute_timeslice
 def supply(
     capacity: xr.DataArray,
     demand: xr.DataArray,
-    technologies: Union[xr.Dataset, xr.DataArray],
-    timeslice_level: Optional[str] = None,
+    technologies: xr.Dataset | xr.DataArray,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     """Production and emission for a given capacity servicing a given demand.
 
@@ -122,7 +124,7 @@ def supply(
 def emission(
     production: xr.DataArray,
     fixed_outputs: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ):
     """Computes emission from current products.
 
@@ -156,7 +158,7 @@ def gross_margin(
     technologies: xr.Dataset,
     capacity: xr.DataArray,
     prices: xr.Dataset,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     """The percentage of revenue after direct expenses have been subtracted.
 
@@ -237,8 +239,8 @@ def gross_margin(
 def decommissioning_demand(
     technologies: xr.Dataset,
     capacity: xr.DataArray,
-    year: Optional[Sequence[int]] = None,
-    timeslice_level: Optional[str] = None,
+    year: Sequence[int] | None = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     r"""Computes demand from process decommissioning.
 
@@ -287,8 +289,8 @@ def decommissioning_demand(
 def consumption(
     technologies: xr.Dataset,
     production: xr.DataArray,
-    prices: Optional[xr.DataArray] = None,
-    timeslice_level: Optional[str] = None,
+    prices: xr.DataArray | None = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     """Commodity consumption when fulfilling the whole production.
 
@@ -363,7 +365,7 @@ def consumption(
 def maximum_production(
     technologies: xr.Dataset,
     capacity: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
     **filters,
 ):
     r"""Production for a given capacity.
@@ -420,8 +422,8 @@ def maximum_production(
 def capacity_in_use(
     production: xr.DataArray,
     technologies: xr.Dataset,
-    max_dim: Optional[Union[str, tuple[str]]] = "commodity",
-    timeslice_level: Optional[str] = None,
+    max_dim: str | tuple[str] | None = "commodity",
+    timeslice_level: str | None = None,
     **filters,
 ):
     """Capacity-in-use for each asset, given production.
@@ -475,7 +477,7 @@ def capacity_in_use(
 def minimum_production(
     technologies: xr.Dataset,
     capacity: xr.DataArray,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
     **filters,
 ):
     r"""Minimum production for a given capacity.
@@ -542,7 +544,7 @@ def minimum_production(
 def capacity_to_service_demand(
     demand: xr.DataArray,
     technologies: xr.Dataset,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     """Minimum capacity required to fulfill the demand."""
     timeslice_outputs = distribute_timeslice(
@@ -558,7 +560,7 @@ def capacity_to_service_demand(
 def production_amplitude(
     production: xr.DataArray,
     technologies: xr.Dataset,
-    timeslice_level: Optional[str] = None,
+    timeslice_level: str | None = None,
 ) -> xr.DataArray:
     """Calculates the degree of technology activity based on production data.
 

--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -1,5 +1,7 @@
 """Ensemble of functions to read MUSE data."""
 
+from __future__ import annotations
+
 __all__ = [
     "read_attribute_table",
     "read_csv_agent_parameters",
@@ -17,7 +19,7 @@ __all__ = [
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional, Union, cast
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -43,9 +45,9 @@ def to_numeric(x):
 
 
 def find_sectors_file(
-    filename: Union[str, Path],
-    sector: Optional[str] = None,
-    sectors_directory: Union[str, Path] = DEFAULT_SECTORS_DIRECTORY,
+    filename: str | Path,
+    sector: str | None = None,
+    sectors_directory: str | Path = DEFAULT_SECTORS_DIRECTORY,
 ) -> Path:
     """Looks through a few standard place for sector files."""
     filename = Path(filename)
@@ -68,7 +70,7 @@ def find_sectors_file(
     raise OSError(msg)
 
 
-def read_technodictionary(filename: Union[str, Path]) -> xr.Dataset:
+def read_technodictionary(filename: str | Path) -> xr.Dataset:
     """Reads and formats technodata into a dataset.
 
     There are three axes: technologies, regions, and year.
@@ -125,7 +127,7 @@ def read_technodictionary(filename: Union[str, Path]) -> xr.Dataset:
     return result
 
 
-def read_technodata_timeslices(filename: Union[str, Path]) -> xr.Dataset:
+def read_technodata_timeslices(filename: str | Path) -> xr.Dataset:
     from muse.readers import camel_to_snake
     from muse.timeslices import sort_timeslices
 
@@ -163,7 +165,7 @@ def read_technodata_timeslices(filename: Union[str, Path]) -> xr.Dataset:
     return sort_timeslices(result)
 
 
-def read_io_technodata(filename: Union[str, Path]) -> xr.Dataset:
+def read_io_technodata(filename: str | Path) -> xr.Dataset:
     """Reads process inputs or outputs.
 
     There are four axes: (technology, region, year, commodity)
@@ -222,7 +224,7 @@ def read_io_technodata(filename: Union[str, Path]) -> xr.Dataset:
     return result
 
 
-def read_initial_assets(filename: Union[str, Path]) -> xr.DataArray:
+def read_initial_assets(filename: str | Path) -> xr.DataArray:
     """Reads and formats data about initial capacity into a dataframe."""
     data = pd.read_csv(filename, float_precision="high", low_memory=False)
     if "Time" in data.columns:
@@ -239,7 +241,7 @@ def read_initial_assets(filename: Union[str, Path]) -> xr.DataArray:
     return result
 
 
-def read_initial_capacity(data: Union[str, Path, pd.DataFrame]) -> xr.DataArray:
+def read_initial_capacity(data: str | Path | pd.DataFrame) -> xr.DataArray:
     if not isinstance(data, pd.DataFrame):
         data = pd.read_csv(data, float_precision="high", low_memory=False)
     if "Unit" in data.columns:
@@ -256,12 +258,12 @@ def read_initial_capacity(data: Union[str, Path, pd.DataFrame]) -> xr.DataArray:
 
 
 def read_technologies(
-    technodata_path_or_sector: Optional[Union[str, Path]] = None,
-    technodata_timeslices_path: Optional[Union[str, Path]] = None,
-    comm_out_path: Optional[Union[str, Path]] = None,
-    comm_in_path: Optional[Union[str, Path]] = None,
-    commodities: Optional[Union[str, Path, xr.Dataset]] = None,
-    sectors_directory: Union[str, Path] = DEFAULT_SECTORS_DIRECTORY,
+    technodata_path_or_sector: str | Path | None = None,
+    technodata_timeslices_path: str | Path | None = None,
+    comm_out_path: str | Path | None = None,
+    comm_in_path: str | Path | None = None,
+    commodities: str | Path | xr.Dataset | None = None,
+    sectors_directory: str | Path = DEFAULT_SECTORS_DIRECTORY,
 ) -> xr.Dataset:
     """Reads data characterising technologies from files.
 
@@ -407,7 +409,7 @@ def read_technologies(
     return result
 
 
-def read_global_commodities(path: Union[str, Path]) -> xr.Dataset:
+def read_global_commodities(path: str | Path) -> xr.Dataset:
     """Reads commodities information from input."""
     from logging import getLogger
 
@@ -439,8 +441,8 @@ def read_global_commodities(path: Union[str, Path]) -> xr.Dataset:
 
 
 def read_timeslice_shares(
-    path: Union[str, Path] = DEFAULT_SECTORS_DIRECTORY,
-    sector: Optional[str] = None,
+    path: str | Path = DEFAULT_SECTORS_DIRECTORY,
+    sector: str | None = None,
 ) -> xr.Dataset:
     """Reads sliceshare information into a xr.Dataset.
 
@@ -553,7 +555,7 @@ def read_csv_agent_parameters(filename) -> list:
     return result
 
 
-def read_macro_drivers(path: Union[str, Path]) -> xr.Dataset:
+def read_macro_drivers(path: str | Path) -> xr.Dataset:
     """Reads a standard MUSE csv file for macro drivers."""
     from logging import getLogger
 
@@ -578,9 +580,9 @@ def read_macro_drivers(path: Union[str, Path]) -> xr.Dataset:
 
 
 def read_initial_market(
-    projections: Union[xr.DataArray, Path, str],
-    base_year_import: Optional[Union[str, Path, xr.DataArray]] = None,
-    base_year_export: Optional[Union[str, Path, xr.DataArray]] = None,
+    projections: xr.DataArray | Path | str,
+    base_year_import: str | Path | xr.DataArray | None = None,
+    base_year_export: str | Path | xr.DataArray | None = None,
 ) -> xr.Dataset:
     """Read projections, import and export csv files."""
     from logging import getLogger
@@ -635,7 +637,7 @@ def read_initial_market(
     return result
 
 
-def read_attribute_table(path: Union[str, Path]) -> xr.DataArray:
+def read_attribute_table(path: str | Path) -> xr.DataArray:
     """Read a standard MUSE csv file for price projections."""
     from logging import getLogger
 
@@ -672,7 +674,7 @@ def read_attribute_table(path: Union[str, Path]) -> xr.DataArray:
     return result
 
 
-def read_regression_parameters(path: Union[str, Path]) -> xr.Dataset:
+def read_regression_parameters(path: str | Path) -> xr.Dataset:
     """Reads the regression parameters from a standard MUSE csv file."""
     from logging import getLogger
 
@@ -730,7 +732,7 @@ def read_regression_parameters(path: Union[str, Path]) -> xr.Dataset:
 
 
 def read_presets(
-    paths: Union[str, Path, Sequence[Union[str, Path]]],
+    paths: str | Path | Sequence[str | Path],
     columns: str = "commodity",
     indices: Sequence[str] = ("RegionName", "Timeslice"),
     drop: Sequence[str] = ("Unnamed: 0",),
@@ -807,13 +809,13 @@ def read_presets(
 
 
 def read_trade(
-    data: Union[pd.DataFrame, str, Path],
+    data: pd.DataFrame | str | Path,
     columns_are_source: bool = True,
-    parameters: Optional[str] = None,
-    skiprows: Optional[Sequence[int]] = None,
-    name: Optional[str] = None,
-    drop: Optional[Union[str, Sequence[str]]] = None,
-) -> Union[xr.DataArray, xr.Dataset]:
+    parameters: str | None = None,
+    skiprows: Sequence[int] | None = None,
+    name: str | None = None,
+    drop: str | Sequence[str] | None = None,
+) -> xr.DataArray | xr.Dataset:
     """Read CSV table with source and destination regions."""
     from muse.readers import camel_to_snake
 
@@ -853,7 +855,7 @@ def read_trade(
         var_name=col_region,
     )
     if parameters is None:
-        result: Union[xr.DataArray, xr.Dataset] = xr.DataArray.from_series(
+        result: xr.DataArray | xr.Dataset = xr.DataArray.from_series(
             data.set_index([*indices, col_region])["value"]
         ).rename(name)
     else:
@@ -867,7 +869,7 @@ def read_trade(
 
 
 def check_utilization_and_minimum_service_factors(
-    data: pd.DataFrame, filename: Union[str, list[str]]
+    data: pd.DataFrame, filename: str | list[str]
 ) -> None:
     filename = [filename] if isinstance(filename, (str, Path)) else filename
     filename = [name for name in filename if name is not None]

--- a/src/muse/readers/toml.py
+++ b/src/muse/readers/toml.py
@@ -1,5 +1,7 @@
 """Ensemble of functions to read MUSE data."""
 
+from __future__ import annotations
+
 __all__ = ["read_settings"]
 
 import importlib.util as implib
@@ -11,8 +13,6 @@ from pathlib import Path
 from typing import (
     IO,
     Any,
-    Optional,
-    Union,
 )
 
 import numpy as np
@@ -72,10 +72,10 @@ class FormatDict(dict):
 
 def format_path(
     filepath: str,
-    replacements: Optional[Mapping] = None,
-    path: Optional[Union[str, Path]] = None,
-    cwd: Optional[Union[str, Path]] = None,
-    muse_sectors: Optional[str] = None,
+    replacements: Mapping | None = None,
+    path: str | Path | None = None,
+    cwd: str | Path | None = None,
+    muse_sectors: str | None = None,
 ):
     """Replaces known patterns in a path.
 
@@ -102,10 +102,10 @@ def format_path(
 
 def format_paths(
     settings: Mapping,
-    replacements: Optional[Mapping] = None,
-    path: Optional[Union[str, Path]] = None,
-    cwd: Optional[Union[str, Path]] = None,
-    muse_sectors: Optional[str] = None,
+    replacements: Mapping | None = None,
+    path: str | Path | None = None,
+    cwd: str | Path | None = None,
+    muse_sectors: str | None = None,
     suffixes: Sequence[str] = (".csv", ".nc", ".xls", ".xlsx", ".py", ".toml"),
 ):
     """Format paths passed to settings.
@@ -249,8 +249,8 @@ def format_paths(
 
 
 def read_split_toml(
-    tomlfile: Union[str, Path, IO[str], Mapping],
-    path: Optional[Union[str, Path]] = None,
+    tomlfile: str | Path | IO[str] | Mapping,
+    path: str | Path | None = None,
 ) -> MutableMapping:
     """Reads and consolidate TOML files.
 
@@ -342,8 +342,8 @@ def read_split_toml(
 
 
 def read_settings(
-    settings_file: Union[str, Path, IO[str], Mapping],
-    path: Optional[Union[str, Path]] = None,
+    settings_file: str | Path | IO[str] | Mapping,
+    path: str | Path | None = None,
 ) -> Any:
     """Loads the input settings for any MUSE simulation.
 
@@ -660,10 +660,10 @@ def check_sectors_files(settings: dict) -> None:
 
 def read_technodata(
     settings: Any,
-    sector_name: Optional[str] = None,
-    time_framework: Optional[Sequence[int]] = None,
-    commodities: Optional[Union[str, Path]] = None,
-    regions: Optional[Sequence[str]] = None,
+    sector_name: str | None = None,
+    time_framework: Sequence[int] | None = None,
+    commodities: str | Path | None = None,
+    regions: Sequence[str] | None = None,
     **kwargs,
 ) -> xr.Dataset:
     """Helper function to create technodata for a given sector."""

--- a/src/muse/registration.py
+++ b/src/muse/registration.py
@@ -1,9 +1,11 @@
 """Registrators that allow pluggable data to logic transforms."""
 
+from __future__ import annotations
+
 __all__ = ["registrator"]
 
 from collections.abc import MutableMapping, Sequence
-from typing import Callable, Optional, Union
+from typing import Callable
 
 
 def name_variations(*args):
@@ -38,10 +40,10 @@ def name_variations(*args):
 
 
 def registrator(
-    decorator: Optional[Callable] = None,
-    registry: Optional[MutableMapping] = None,
-    logname: Optional[str] = None,
-    loglevel: Optional[str] = "Debug",
+    decorator: Callable | None = None,
+    registry: MutableMapping | None = None,
+    logname: str | None = None,
+    loglevel: str | None = "Debug",
 ) -> Callable:
     """A decorator to create a decorator that registers functions with MUSE.
 
@@ -133,7 +135,7 @@ def registrator(
     @wraps(decorator)
     def register(
         function=None,
-        name: Optional[Union[str, Sequence[str]]] = None,
+        name: str | Sequence[str] | None = None,
         vary_name: bool = True,
         overwrite: bool = False,
     ):

--- a/src/muse/sectors/register.py
+++ b/src/muse/sectors/register.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections.abc import Mapping, Sequence
-from typing import Callable, Optional, Union
+from typing import Callable
 
 from muse.sectors.abstract import AbstractSector
 
@@ -8,8 +10,8 @@ SECTORS_REGISTERED: Mapping[str, Callable] = {}
 
 
 def register_sector(
-    sector_class: Optional[type[AbstractSector]] = None,
-    name: Optional[Union[str, Sequence[str]]] = None,
+    sector_class: type[AbstractSector] | None = None,
+    name: str | Sequence[str] | None = None,
 ) -> type[AbstractSector]:
     """Registers a sector so it is available MUSE-wide.
 

--- a/src/muse/timeslices.py
+++ b/src/muse/timeslices.py
@@ -1,5 +1,7 @@
 """Timeslice utility functions."""
 
+from __future__ import annotations
+
 __all__ = [
     "broadcast_timeslice",
     "compress_timeslice",
@@ -14,7 +16,6 @@ __all__ = [
 ]
 
 from collections.abc import Mapping, Sequence
-from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -24,7 +25,7 @@ TIMESLICE: DataArray = None  # type: ignore
 
 
 def read_timeslices(
-    settings: Union[Mapping, str],
+    settings: Mapping | str,
     level_names: Sequence[str] = ("month", "day", "hour"),
 ) -> DataArray:
     from functools import reduce
@@ -75,14 +76,14 @@ def read_timeslices(
     return DataArray(ts, coords={"timeslice": indices}, dims="timeslice")
 
 
-def setup_module(settings: Union[str, Mapping]):
+def setup_module(settings: str | Mapping):
     """Sets up module singletons."""
     global TIMESLICE
     TIMESLICE = read_timeslices(settings)
 
 
 def broadcast_timeslice(
-    data: DataArray, ts: Optional[DataArray] = None, level: Optional[str] = None
+    data: DataArray, ts: DataArray | None = None, level: str | None = None
 ) -> DataArray:
     """Convert a non-timesliced array to a timesliced array by broadcasting.
 
@@ -119,7 +120,7 @@ def broadcast_timeslice(
 
 
 def distribute_timeslice(
-    data: DataArray, ts: Optional[DataArray] = None, level=None
+    data: DataArray, ts: DataArray | None = None, level=None
 ) -> DataArray:
     """Convert a non-timesliced array to a timesliced array by distribution.
 
@@ -153,8 +154,8 @@ def distribute_timeslice(
 
 def compress_timeslice(
     data: DataArray,
-    ts: Optional[DataArray] = None,
-    level: Optional[str] = None,
+    ts: DataArray | None = None,
+    level: str | None = None,
     operation: str = "sum",
 ) -> DataArray:
     """Convert a fully timesliced array to a coarser level.
@@ -214,7 +215,7 @@ def compress_timeslice(
 
 
 def expand_timeslice(
-    data: DataArray, ts: Optional[DataArray] = None, operation: str = "distribute"
+    data: DataArray, ts: DataArray | None = None, operation: str = "distribute"
 ) -> DataArray:
     """Convert a timesliced array to a finer level.
 
@@ -294,7 +295,7 @@ def get_level(data: DataArray) -> str:
     return data.timeslice.to_index().names[-1]
 
 
-def sort_timeslices(data: DataArray, ts: Optional[DataArray] = None) -> DataArray:
+def sort_timeslices(data: DataArray, ts: DataArray | None = None) -> DataArray:
     """Sorts the timeslices of a DataArray according to a reference timeslice.
 
     This will only sort timeslices to match the reference if the data is at the same
@@ -315,7 +316,7 @@ def sort_timeslices(data: DataArray, ts: Optional[DataArray] = None) -> DataArra
     return data.sortby("timeslice")
 
 
-def timeslice_max(data: DataArray, ts: Optional[DataArray] = None) -> DataArray:
+def timeslice_max(data: DataArray, ts: DataArray | None = None) -> DataArray:
     """Find the max value over the timeslice dimension, normalized for timeslice length.
 
     This first annualizes the value in each timeslice by dividing by the fraction of the


### PR DESCRIPTION
Some files were still using the old style of type annotations. I've updated all files to use the modern syntax

Process: Added `from __future__ import annotations` to the top of every file (if not already present), and ran ruff with the `unsafe-fixes` option