### PR TITLE
Make capacity growth parameters optional

### DIFF
--- a/docs/inputs/technodata.rst
+++ b/docs/inputs/technodata.rst
@@ -81,7 +81,7 @@ var_par, var_exp
 
    ProductionRef is the production of a reference capacity (CapRef) for the cost estimate decided by the modeller before filling the input data files.
 
-Growith constraints
+Growith constraints (optional)
    MaxCapacityAddition
       represents the maximum addition of installed capacity per technology, per year in a period, per region.
 

--- a/docs/inputs/technodata.rst
+++ b/docs/inputs/technodata.rst
@@ -107,6 +107,8 @@ Growith constraints (optional)
    Growth constraints are applied for each single agent in a multi-agent simulation. When only one agent is present, the growth constraints
    apply individually to the "New" and "Retrofit" agent, when present.
 
+   If any of the three parameters are not provided in the technodata file, that particular constraint is not applied.
+
 
 TechnicalLife
    represents the number of years that a technology operates before it is decommissioned.

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -310,6 +310,10 @@ def max_capacity_expansion(
         .. math::
 
             \Gamma_t^{r, i} \geq 0
+
+    :math:`L_t^r(y)`, :math:`G_t^r(y)` and :math:`W_t^r(y)` default to np.inf if
+    not provided (i.e. no constraint).
+    If all three parameters are not provided, no constraint is applied (returns None).
     """
     # If all three parameters are missing, don't apply the constraint
     if not any(

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -481,6 +481,24 @@ def test_max_capacity_expansion(max_capacity_expansion):
     ).all()
 
 
+def test_max_capacity_expansion_no_limits(
+    market_demand, capacity, search_space, technologies
+):
+    from muse.constraints import max_capacity_expansion
+
+    # Without growth limits, the constraint should return None
+    techs = technologies.drop_vars(
+        ["max_capacity_addition", "max_capacity_growth", "total_capacity_limit"]
+    )
+    result = max_capacity_expansion(
+        market_demand,
+        capacity,
+        search_space,
+        techs,
+    )
+    assert result is None
+
+
 def test_max_production(max_production):
     dims = {"replacement", "asset", "commodity", "timeslice"}
     assert set(max_production.capacity.dims) == dims


### PR DESCRIPTION
# Description

This is a small change to make the MaxCapacityAddition, MaxCapacityGrowth and TotalCapacityLimit parameters optional.

I've found that many users just set these to very high values so that the constraint effectively doesn't apply, but this is annoying and messy.

It's already possible to exclude this constraint by modifying `constraints` in settings.toml, but this is a bit fiddly and in general I don't think users should be modifying `constraints` (I encourage users to leave this out of their settings files so all the constraints are used by default).

I think the change here to make these parameters optional is more user friendly, as all users need to do now is delete the relevant columns if they don't want to use the constraint for that sector.

Close #667 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
