### PR TITLE
Fix `same_enduse` and `spend_limit` filters

### DIFF
--- a/src/muse/agents/agent.py
+++ b/src/muse/agents/agent.py
@@ -315,7 +315,9 @@ class InvestingAgent(Agent):
 
         # Calculate the search space
         search_space = (
-            self.search_rules(self, demand, technologies, market).fillna(0).astype(int)
+            self.search_rules(self, demand, technologies=technologies, market=market)
+            .fillna(0)
+            .astype(int)
         )
 
         # Skip forward if the search space is empty

--- a/src/muse/examples.py
+++ b/src/muse/examples.py
@@ -420,7 +420,7 @@ def _trade_search_space(sector: str, model: str = "default") -> xr.DataArray:
                 a.uuid: cast(Agent, a).search_rules(
                     agent=a,
                     demand=market.consumption.isel(year=0, drop=True),
-                    technologies=loaded_sector.technologies,
+                    technologies=loaded_sector.technologies.isel(year=0, drop=True),
                     market=market,
                 )
                 for a in loaded_sector.agents

--- a/src/muse/filters.py
+++ b/src/muse/filters.py
@@ -90,6 +90,7 @@ __all__ = [
     "with_asset_technology",
 ]
 
+import inspect
 from collections.abc import Mapping, MutableMapping, Sequence
 from typing import (
     Any,
@@ -134,6 +135,14 @@ def register_filter(function: SSF_SIGNATURE) -> Callable:
     def decorated(
         agent: Agent, search_space: xr.DataArray, *args, **kwargs
     ) -> xr.DataArray:
+        # Check inputs
+        sig = inspect.signature(function)
+        params = sig.parameters
+        if "technologies" in params:
+            bound_args = sig.bind(agent, search_space, *args, **kwargs)
+            technologies = bound_args.arguments["technologies"]
+            assert "year" not in technologies.dims
+
         result = function(agent, search_space, *args, **kwargs)  # type: ignore
         if isinstance(result, xr.DataArray):
             result.name = search_space.name

--- a/src/muse/filters.py
+++ b/src/muse/filters.py
@@ -244,7 +244,6 @@ def same_enduse(
 
     tech_enduses = agent.filter_input(
         technologies.fixed_outputs,
-        year=agent.year,
         commodity=is_enduse(technologies.comm_usage),
     )
     tech_enduses = (tech_enduses > 0).astype(int).rename(technology="replacement")
@@ -366,7 +365,7 @@ def spend_limit(
 ) -> xr.DataArray:
     """Only allows technologies with a unit capital cost lower than the spend limit."""
     limit = agent.spend_limit
-    unit_capex = agent.filter_input(technologies.cap_par, year=agent.year)
+    unit_capex = agent.filter_input(technologies.cap_par)
     condition = (unit_capex <= limit).rename("spend_limit")
     techs = (
         condition.technology.where(condition, drop=True).drop_vars("technology").values

--- a/src/muse/filters.py
+++ b/src/muse/filters.py
@@ -137,8 +137,7 @@ def register_filter(function: SSF_SIGNATURE) -> Callable:
     ) -> xr.DataArray:
         # Check inputs
         sig = inspect.signature(function)
-        params = sig.parameters
-        if "technologies" in params:
+        if "technologies" in sig.parameters:
             bound_args = sig.bind(agent, search_space, *args, **kwargs)
             technologies = bound_args.arguments["technologies"]
             assert "year" not in technologies.dims

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -18,6 +18,12 @@ def search_space(retro_agent, technologies):
     )
 
 
+@fixture
+def technologies(technologies):
+    # Filters must take technology data for a single year
+    return technologies.sel(year=2010)
+
+
 @mark.usefixtures("save_registries")
 def test_filter_registering():
     from muse.filters import SEARCH_SPACE_FILTERS
@@ -68,9 +74,7 @@ def test_same_enduse(retro_agent, technologies, search_space):
 
     result = same_enduse(retro_agent, search_space, technologies)
     enduses = is_enduse(technologies.comm_usage)
-    finputs = technologies.sel(
-        region=retro_agent.region, year=retro_agent.year, commodity=enduses
-    )
+    finputs = technologies.sel(region=retro_agent.region, commodity=enduses)
     finputs = finputs.fixed_outputs > 0
 
     expected = search_space.copy()


### PR DESCRIPTION
Tiny fix, but the `same_enduse` and `spend_limit` filters were failing because they tried to filter the `technologies` dataset by year, but it's already been filtered by year [here](https://github.com/EnergySystemsModellingLab/MUSE_OS/blob/3a0bb4aebcaaba28d41dd3d3b8f9806ed01d1b96/src/muse/sectors/sector.py#L204) so complains when trying to use these filters.

I've fixed that bug. 

Also added a check to the decorator to enforce that `technologies` cannot have a year dimension. This was a bit trickier than usual as not all filters take `technologies`, so I had to get creative using `inspect`. Not sure if there's a better way to do this.

Had to make a few other changes to keep the tests happy

EDIT: Switched to the approach suggested by Diego below