### PR TITLE
Account for zero interest rates in CRF calculation

### DIFF
--- a/src/muse/costs.py
+++ b/src/muse/costs.py
@@ -528,6 +528,8 @@ def capital_recovery_factor(technologies: xr.Dataset) -> xr.DataArray:
     .. _capital recovery factor:
         https://www.homerenergy.com/products/pro/docs/3.15/capital_recovery_factor.html
 
+    If the interest rate is zero, this simplifies to 1 / nyears
+
     Arguments:
         technologies: All the technologies
 
@@ -535,9 +537,14 @@ def capital_recovery_factor(technologies: xr.Dataset) -> xr.DataArray:
         xr.DataArray with the CRF calculated for the relevant technologies
     """
     nyears = technologies.technical_life.astype(int)
-    crf = technologies.interest_rate / (
-        1 - (1 / (1 + technologies.interest_rate) ** nyears)
+    interest_rate = technologies.interest_rate
+
+    crf = xr.where(
+        interest_rate == 0,
+        1 / nyears,
+        interest_rate / (1 - (1 / (1 + interest_rate) ** nyears)),
     )
+
     assert "year" not in crf.dims
     return crf
 

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,4 +1,4 @@
-from numpy import isclose
+from numpy import isclose, isfinite
 from pytest import fixture, mark, raises
 
 YEAR = 2030
@@ -186,6 +186,11 @@ def test_capital_recovery_factor(_technologies):
     result = capital_recovery_factor(_technologies)
     assert set(result.dims) == set(_technologies.interest_rate.dims)
     # {"region", "technology"}
+
+    # Make sure zero interest rates are supported
+    _technologies["interest_rate"] = 0
+    result = capital_recovery_factor(_technologies)
+    assert isfinite(result).all()
 
 
 def test_annual_to_lifetime(_technologies, _prices, _consumption):


### PR DESCRIPTION
# Description

The calculation of the capital recovery factor (which uses [this equation](https://www.homerenergy.com/products/pro/docs/3.15/capital_recovery_factor.html)) is currently not set up to support zero interest rates. This is because the equation becomes 0/0 when i is zero, which is undefined (and results in nan in the program).

If the interest rate is zero, we need to use a different crf equation: simply 1/lifetime (i.e. the capital costs get spread equally over all years).

You can prove mathematically that the crf equation tends towards 1/lifetime as i tends to zero, but I won't do that here. Intuitively it makes sense though.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
