### PR TITLE
Delete interest_rate parameter from settings file

### DIFF
--- a/docs/inputs/toml.rst
+++ b/docs/inputs/toml.rst
@@ -25,7 +25,6 @@ a whole.
 
    time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
    regions = ["USA"]
-   interest_rate = 0.1
    interpolation_mode = 'linear'
    log_level = 'info'
 

--- a/docs/tutorial-code/add-agent/1-single-objective/settings.toml
+++ b/docs/tutorial-code/add-agent/1-single-objective/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/docs/tutorial-code/add-agent/2-multiple-objective/settings.toml
+++ b/docs/tutorial-code/add-agent/2-multiple-objective/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/docs/tutorial-code/add-correlation-demand/1-correlation/settings.toml
+++ b/docs/tutorial-code/add-correlation-demand/1-correlation/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/docs/tutorial-code/add-new-technology/1-introduction/settings.toml
+++ b/docs/tutorial-code/add-new-technology/1-introduction/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]

--- a/docs/tutorial-code/add-new-technology/2-scenario/settings.toml
+++ b/docs/tutorial-code/add-new-technology/2-scenario/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]

--- a/docs/tutorial-code/add-region/1-new-region/settings.toml
+++ b/docs/tutorial-code/add-region/1-new-region/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1", "R2"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/docs/tutorial-code/add-service-demand/1-exogenous-demand/settings.toml
+++ b/docs/tutorial-code/add-service-demand/1-exogenous-demand/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/docs/tutorial-code/carbon-budget/1-carbon-budget/settings.toml
+++ b/docs/tutorial-code/carbon-budget/1-carbon-budget/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/docs/tutorial-code/min-max-timeslice-constraints/1-min-constraint/settings.toml
+++ b/docs/tutorial-code/min-max-timeslice-constraints/1-min-constraint/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/docs/tutorial-code/min-max-timeslice-constraints/2-max-constraint/settings.toml
+++ b/docs/tutorial-code/min-max-timeslice-constraints/2-max-constraint/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/docs/tutorial-code/modify-timing-data/1-modify-timeslices/settings.toml
+++ b/docs/tutorial-code/modify-timing-data/1-modify-timeslices/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/docs/tutorial-code/modify-timing-data/2-modify-time-framework/settings.toml
+++ b/docs/tutorial-code/modify-timing-data/2-modify-time-framework/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2022, 2024, 2026, 2028, 2030, 2032, 2034, 2036, 2038, 2040]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/docs/tutorial-code/new-decision-metric/settings.toml
+++ b/docs/tutorial-code/new-decision-metric/settings.toml
@@ -2,7 +2,6 @@ plugins = "{path}/new_decision.py"
 # Global settings - most REQUIRED
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind", "solar"]

--- a/src/muse/data/default_settings.toml
+++ b/src/muse/data/default_settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = 'REQUIRED'
 regions = 'REQUIRED'
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 # Convergence parameters

--- a/src/muse/data/example/default/settings.toml
+++ b/src/muse/data/example/default/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/src/muse/data/example/default_retro/settings.toml
+++ b/src/muse/data/example/default_retro/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/src/muse/data/example/default_timeslice/settings.toml
+++ b/src/muse/data/example/default_timeslice/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/src/muse/data/example/minimum_service/settings.toml
+++ b/src/muse/data/example/minimum_service/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2010, 2015, 2020, 2025, 2030, 2035, 2040, 2045, 2050]
 regions = ["R1"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["fuel1", "fuel2", "fuel3"]

--- a/src/muse/data/example/trade/settings.toml
+++ b/src/muse/data/example/trade/settings.toml
@@ -2,7 +2,6 @@
 
 time_framework = [2020, 2025, 2030, 2035]
 regions = ["R1", "R2"]
-interest_rate = 0.1
 interpolation_mode = 'linear'
 log_level = 'info'
 excluded_commodities = ["wind"]

--- a/src/muse/mca.py
+++ b/src/muse/mca.py
@@ -93,7 +93,7 @@ class MCA:
             if not hasattr(v, "_asdict") and k not in extras
         }
 
-        # Legacy: warn user about deprecated parameters (#641)
+        # Legacy: warn user about deprecated parameters (#641, #679)
         deprecated_params = ["foresight", "interest_rate"]
         for param in deprecated_params:
             if param in global_kw:

--- a/src/muse/mca.py
+++ b/src/muse/mca.py
@@ -79,7 +79,6 @@ class MCA:
 
         extras = {
             "regions",
-            "interest_rate",
             "log_level",
             "interpolation_mode",
             "timeslices",
@@ -94,14 +93,16 @@ class MCA:
             if not hasattr(v, "_asdict") and k not in extras
         }
 
-        # Legacy: warn user about deprecation of "foresight" parameter (#641)
-        if "foresight" in global_kw:
-            msg = (
-                "The `foresight` parameter has been deprecated. "
-                "Please remove from your settings file."
-            )
-            getLogger(__name__).warning(msg)
-            global_kw.pop("foresight")
+        # Legacy: warn user about deprecated parameters (#641)
+        deprecated_params = ["foresight", "interest_rate"]
+        for param in deprecated_params:
+            if param in global_kw:
+                msg = (
+                    f"The `{param}` parameter has been deprecated. "
+                    "Please remove it from your settings file."
+                )
+                getLogger(__name__).warning(msg)
+                global_kw.pop(param)
 
         carbon_kw = {
             k: v._asdict() if hasattr(v, "_asdict") else v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -485,7 +485,6 @@ def settings(tmpdir) -> dict:
     required = {
         "time_framework": [2010, 2015, 2020],
         "regions": ["MEX"],
-        "interest_rate": 0.1,
         "equilibrium": False,
         "maximum_iterations": 3,
         "tolerance": 0.1,


### PR DESCRIPTION
# Description

I assume at some point there was a global interest rate for all technologies, but now we specify interest rate at the technology level in the technodata files, so this global parameter isn't used.

I've deleted it from all settings files,  and added a warning to encourage users to remove it