### PR TITLE
Restore regressions test for tutorials

### DIFF
--- a/tests/test_fullsim_regression.py
+++ b/tests/test_fullsim_regression.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pytest import mark
+from pytest import mark, xfail
 
 from muse.examples import available_examples
 
@@ -52,9 +52,7 @@ def test_tutorial_regression(tutorial_path, tmpdir, compare_dirs):
 
     # Mark as xfail for a specific tutorial
     if "modify-time-framework" in str(tutorial_path):
-        mark.xfail(reason="Known issue with this tutorial (#371)")(
-            test_tutorial_regression
-        )
+        xfail(reason="Known issue with this tutorial (#371)")
 
     # fail the test if this warning crops up
     simplefilter("error", DtypeWarning)

--- a/tests/test_fullsim_regression.py
+++ b/tests/test_fullsim_regression.py
@@ -36,7 +36,7 @@ def test_fullsim_regression(model, tmpdir, compare_dirs):
 
 def available_tutorials():
     base_path = Path(__file__).parent.parent / "docs" / "tutorial-code"
-    return [d.parent for d in base_path.rglob("*/input") if d.is_dir()]
+    return [p.parent for p in base_path.rglob("settings.toml")]
 
 
 @mark.regression


### PR DESCRIPTION
Accidentally messed this up in #672 so the regression test haven't been running for the tutorials (oops)