### PR TITLE
Fix bug defining subsector commodities when zero existing capacity

### DIFF
--- a/src/muse/agents/factories.py
+++ b/src/muse/agents/factories.py
@@ -169,7 +169,7 @@ def create_agent(agent_type: str, **kwargs) -> Agent:
 
 def agents_factory(
     params_or_path: str | Path | list,
-    capacity: xr.DataArray | str | Path,
+    capacity: xr.DataArray,
     technologies: xr.Dataset,
     regions: Sequence[str] | None = None,
     year: int | None = None,
@@ -179,14 +179,12 @@ def agents_factory(
     from copy import deepcopy
     from logging import getLogger
 
-    from muse.readers import read_csv_agent_parameters, read_initial_assets
+    from muse.readers import read_csv_agent_parameters
 
     if isinstance(params_or_path, (str, Path)):
         params = read_csv_agent_parameters(params_or_path)
     else:
         params = params_or_path
-    if isinstance(capacity, (str, Path)):
-        capacity = read_initial_assets(capacity)
     assert isinstance(capacity, xr.DataArray)
     if year is None:
         year = int(capacity.year.min())

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -548,9 +548,8 @@ def demand_limiting_capacity(
     # meet the demand which would be a combination of a high demand and a low
     # utilization factor.
     if "timeslice" in b.dims or "timeslice" in capacity.dims:
-        ratio = b / capacity.max("replacement")
-        ratio = ratio.where(b != 0, 0.0)
-        ts_index = ratio.argmax("timeslice")
+        ratio = b / capacity
+        ts_index = ratio.min("replacement").argmax("timeslice")
         b = b.isel(timeslice=ts_index)
         capacity = capacity.isel(timeslice=ts_index)
 

--- a/src/muse/constraints.py
+++ b/src/muse/constraints.py
@@ -548,8 +548,9 @@ def demand_limiting_capacity(
     # meet the demand which would be a combination of a high demand and a low
     # utilization factor.
     if "timeslice" in b.dims or "timeslice" in capacity.dims:
-        ratio = b / capacity
-        ts_index = ratio.min("replacement").argmax("timeslice")
+        ratio = b / capacity.max("replacement")
+        ratio = ratio.where(b != 0, 0.0)
+        ts_index = ratio.argmax("timeslice")
         b = b.isel(timeslice=ts_index)
         capacity = capacity.isel(timeslice=ts_index)
 

--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -79,6 +79,11 @@ class Subsector:
         # Select commodity demands for the subsector
         demands = market.consumption.sel(commodity=self.commodities)
 
+        # Remove commodities that have no demand
+        demands = demands.sel(
+            commodity=demands.sum([u for u in demands.dims if u != "commodity"]) > 0.0
+        )
+
         # Split demand across agents
         demands = self.demand_share(
             agents=self.agents,

--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -79,10 +79,9 @@ class Subsector:
         # Select commodity demands for the subsector
         demands = market.consumption.sel(commodity=self.commodities)
 
-        # Remove commodities that have no demand
-        demands = demands.sel(
-            commodity=demands.sum([u for u in demands.dims if u != "commodity"]) > 0.0
-        )
+        # Remove commodities that have no demand in the investment year
+        mask = (demands.isel(year=1, drop=True) > 0).any(dim=["timeslice", "region"])
+        demands = demands.sel(commodity=mask)
 
         # Split demand across agents
         demands = self.demand_share(

--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -221,7 +221,13 @@ class Subsector:
 
 
 def aggregate_enduses(technologies: xr.Dataset) -> list[str]:
-    """Aggregate enduse commodities for a set of technologies."""
+    """Aggregate enduse commodities for a set of technologies.
+
+    Returns a list of all enduse commodities associated with the technologies in the
+    input dataset. Enduse commodities are determined using based on the `comm_usage`
+    attribute of the technologies, using the `is_enduse` function from the
+    `muse.commodities` module.
+    """
     from muse.commodities import is_enduse
 
     return technologies.commodity.values[is_enduse(technologies.comm_usage)].tolist()

--- a/tests/test_subsector.py
+++ b/tests/test_subsector.py
@@ -36,9 +36,7 @@ def test_subsector_investing_aggregation():
             agents = list(examples.sector(sname, model).agents)
             sector = next(sector for sector in mca.sectors if sector.name == sname)
             technologies = sector.technologies
-            commodities = aggregate_enduses(
-                (agent.assets for agent in agents), technologies
-            )
+            commodities = aggregate_enduses(technologies)
             market = mca.market.sel(
                 commodity=technologies.commodity, region=technologies.region
             ).interp(year=[2020, 2025])
@@ -89,7 +87,7 @@ def test_subsector_noninvesting_aggregation(market, model, technologies, tmp_pat
         param["decision"]["parameters"] = ("ALCOE", False, 1)
         param.pop("quantity")
     agents = [create_agent(technologies=technologies, **param) for param in params]
-    commodities = aggregate_enduses((agent.assets for agent in agents), technologies)
+    commodities = aggregate_enduses(technologies)
 
     subsector = Subsector(
         agents,


### PR DESCRIPTION
# Description

MUSE uses subsectors which are in charge of one or more commodities. Users can explicitly pass a list of commodities in the settings file, or MUSE can infer the commodities based on the `ExistingCapacity` file.

However, there's a problem with how this is done. MUSE first creates assets from the `ExistingCapacity`, then aggregates the end-use commodities from these assets. However, if there are technologies in `ExistingCapacity` with zero initial capacity, no assets will be created for these, and these won't be included in the end-use aggregation process.

E.g. a refineries sector may be in charge of oil and hydrogen. If there's no initial demand for hydrogen, the user will set initial capacity for hydrogen-producing technologies to zero. However, demand for hydrogen may increase in the future, so we still want to include hydrogen in the subsector's `self.commodities` so that hydrogen demand get's passed to the subsector.

I've fixed this by aggregating the enduse commodities from `ExistingCapacity` directly. 

I've added another step during investment to remove commodities with zero demand. E.g in the above example we wouldn't want it to perform investments to meet hydrogen demand when demand is zero (there will be no investments, but it's just a waste of computation). This is probably a good thing to do anyway, but seemed especially appropriate now.

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
