### PR TITLE
Fix bug in aggregate_enduses

### DIFF
--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -230,4 +230,9 @@ def aggregate_enduses(technologies: xr.Dataset) -> list[str]:
     """
     from muse.commodities import is_enduse
 
-    return technologies.commodity.values[is_enduse(technologies.comm_usage)].tolist()
+    # We select enduse commodities with positive fixed outputs
+    enduse_output = technologies.fixed_outputs.any(
+        [u for u in technologies.dims if u != "commodity"]
+    ) * is_enduse(technologies.comm_usage)
+
+    return technologies.commodity.values[enduse_output].tolist()

--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -231,8 +231,9 @@ def aggregate_enduses(technologies: xr.Dataset) -> list[str]:
     from muse.commodities import is_enduse
 
     # We select enduse commodities with positive fixed outputs
-    enduse_output = technologies.fixed_outputs.any(
-        [u for u in technologies.dims if u != "commodity"]
+    outputs = technologies.fixed_outputs
+    enduse_output = outputs.any(
+        [u for u in outputs.dims if u != "commodity"]
     ) * is_enduse(technologies.comm_usage)
 
     return technologies.commodity.values[enduse_output].tolist()


### PR DESCRIPTION
# Description

There was a mistake in `aggregate_enduses` introduced in #703. As well as checking which commodities are enduses (using `is_enduse`), we also need to check that technologies in the subsector produce these commodities (i.e. positive `fixed_outputs`)

Fixes #707 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
