### PR TITLE
More reader tests

### DIFF
--- a/src/muse/sectors/preset_sector.py
+++ b/src/muse/sectors/preset_sector.py
@@ -7,7 +7,6 @@ from typing import Any
 from xarray import DataArray, Dataset
 
 from muse.sectors.register import AbstractSector, register_sector
-from muse.timeslices import drop_timeslice
 
 
 @register_sector(name=("preset", "presets"))
@@ -17,107 +16,10 @@ class PresetSector(AbstractSector):  # type: ignore
     @classmethod
     def factory(cls, name: str, settings: Any) -> PresetSector:
         """Constructs a PresetSectors from input data."""
-        from collections.abc import Sequence
+        from muse.readers.toml import read_presets_sector
 
-        from xarray import DataArray, zeros_like
-
-        from muse.commodities import CommodityUsage
-        from muse.readers import (
-            read_attribute_table,
-            read_macro_drivers,
-            read_presets,
-            read_regression_parameters,
-            read_timeslice_shares,
-        )
-        from muse.regressions import endogenous_demand
-        from muse.timeslices import TIMESLICE, broadcast_timeslice, distribute_timeslice
-
+        presets = read_presets_sector(settings, name)
         sector_conf = getattr(settings.sectors, name)
-        presets = Dataset()
-
-        timeslice = TIMESLICE.timeslice
-        if getattr(sector_conf, "consumption_path", None) is not None:
-            consumption = read_presets(sector_conf.consumption_path)
-            presets["consumption"] = consumption.assign_coords(timeslice=timeslice)
-        elif getattr(sector_conf, "demand_path", None) is not None:
-            presets["consumption"] = read_attribute_table(sector_conf.demand_path)
-        elif (
-            getattr(sector_conf, "macrodrivers_path", None) is not None
-            and getattr(sector_conf, "regression_path", None) is not None
-        ):
-            macro_drivers = read_macro_drivers(
-                getattr(sector_conf, "macrodrivers_path", None)
-            )
-            regression_parameters = read_regression_parameters(
-                getattr(sector_conf, "regression_path", None)
-            )
-            forecast = getattr(sector_conf, "forecast", 0)
-            if isinstance(forecast, Sequence):
-                forecast = DataArray(
-                    forecast, coords={"forecast": forecast}, dims="forecast"
-                )
-            consumption = endogenous_demand(
-                drivers=macro_drivers,
-                regression_parameters=regression_parameters,
-                forecast=forecast,
-            )
-            if hasattr(sector_conf, "filters"):
-                consumption = consumption.sel(sector_conf.filters._asdict())
-            if "sector" in consumption.dims:
-                consumption = consumption.sum("sector")
-
-            if getattr(sector_conf, "timeslice_shares_path", None) is not None:
-                assert isinstance(timeslice, DataArray)
-                shares = read_timeslice_shares(sector_conf.timeslice_shares_path)
-                shares = shares.assign_coords(timeslice=timeslice)
-                assert consumption.commodity.isin(shares.commodity).all()
-                assert consumption.region.isin(shares.region).all()
-                consumption = broadcast_timeslice(consumption) * shares.sel(
-                    region=consumption.region, commodity=consumption.commodity
-                )
-            presets["consumption"] = consumption
-
-        if getattr(sector_conf, "supply_path", None) is not None:
-            supply = read_presets(sector_conf.supply_path)
-            supply.coords["timeslice"] = presets.timeslice
-            presets["supply"] = supply
-
-        if getattr(sector_conf, "costs_path", None) is not None:
-            presets["costs"] = read_attribute_table(sector_conf.costs_path)
-        elif (
-            getattr(sector_conf, "lcoe_path", None) is not None and "supply" in presets
-        ):
-            costs = (
-                read_presets(
-                    sector_conf.lcoe_path,
-                    indices=("RegionName",),
-                    columns="timeslices",
-                )
-                * presets["supply"]
-            )
-            presets["costs"] = costs
-
-        if len(presets.data_vars) == 0:
-            raise OSError("None of supply, consumption, costs given")
-
-        # add missing data as zeros: we only need one of consumption, costs, supply
-        components = {"supply", "consumption", "costs"}
-        for component in components:
-            others = components.intersection(presets.data_vars).difference({component})
-            if component not in presets and len(others) > 0:
-                presets[component] = drop_timeslice(zeros_like(presets[others.pop()]))
-
-        # add timeslice, if missing
-        for component in {"supply", "consumption"}:
-            if "timeslice" not in presets[component].dims:
-                presets[component] = distribute_timeslice(presets[component])
-
-        comm_usage = (presets.costs > 0).any(set(presets.costs.dims) - {"commodity"})
-        presets["comm_usage"] = (
-            "commodity",
-            [CommodityUsage.PRODUCT if u else CommodityUsage.OTHER for u in comm_usage],
-        )
-        presets = presets.set_coords("comm_usage")
         interpolation_mode = getattr(sector_conf, "interpolation_mode", "linear")
         return cls(presets, interpolation_mode=interpolation_mode, name=name)
 

--- a/tests/test_csv_readers.py
+++ b/tests/test_csv_readers.py
@@ -922,7 +922,7 @@ def test_read_technodata(model_path):
             "technology": ["gasCCGT", "windturbine"],
             "region": ["R1"],
             "year": [2020, 2025, 2030, 2035, 2040, 2045, 2050],
-            "comm_usage": [10, 9, 8, 6, 9],
+            "comm_usage": [10, 9, 6, 9],
         },
     )
 
@@ -987,6 +987,7 @@ def test_read_technodata__trade(trade_model_path):
             "technology": ["gasCCGT", "windturbine"],
             "region": ["R1", "R2"],
             "dst_region": ["R1", "R2"],
+            "comm_usage": [10, 9, 6, 9],
             "year": [2010, 2020, 2025, 2030, 2035],
         },
     )
@@ -1023,6 +1024,7 @@ def test_read_presets_sector(model_path):
             "year": [2020, 2050],
             "commodity": COMMODITIES,
             "timeslice": EXPECTED_TIMESLICES,
+            "comm_usage": [0, 0, 0, 0, 0],
         },
     )
 
@@ -1073,6 +1075,7 @@ def test_read_presets_sector__correlation(correlation_model_path):
             "year": range(2010, 2111),
             "commodity": ["electricity", "gas", "heat", "CO2f"],
             "timeslice": EXPECTED_TIMESLICES,
+            "comm_usage": [0, 0, 0, 0, 0],
         },
     )
 

--- a/tests/test_csv_readers.py
+++ b/tests/test_csv_readers.py
@@ -728,3 +728,66 @@ def test_read_regression_parameters(correlation_model_path):
         "GDPscaleGreater": 672.9316672,
     }
     assert_single_coordinate(data, coord, expected)
+
+
+def test_read_technologies(model_path):
+    from muse.readers.csv import read_technologies
+
+    data = read_technologies(
+        technodata_path_or_sector=model_path / "power" / "Technodata.csv",
+        comm_out_path=model_path / "power" / "CommOut.csv",
+        comm_in_path=model_path / "power" / "CommIn.csv",
+        commodities=model_path / "GlobalCommodities.csv",
+    )
+
+    # Check data against schema
+    expected_schema = DatasetSchema(
+        dims={"commodity", "technology", "region", "year"},
+        coords={
+            "technology": CoordinateSchema(dims=("technology",), dtype="object"),
+            "region": CoordinateSchema(dims=("region",), dtype="object"),
+            "year": CoordinateSchema(dims=("year",), dtype="int64"),
+            "commodity": CoordinateSchema(dims=("commodity",), dtype="object"),
+            "comm_usage": CoordinateSchema(dims=("commodity",), dtype="object"),
+        },
+        data_vars={
+            "cap_par": "float64",
+            "cap_exp": "int64",
+            "fix_par": "int64",
+            "fix_exp": "int64",
+            "var_par": "int64",
+            "var_exp": "int64",
+            "max_capacity_addition": "int64",
+            "max_capacity_growth": "float64",
+            "total_capacity_limit": "int64",
+            "technical_life": "int64",
+            "utilization_factor": "float64",
+            "scaling_size": "float64",
+            "efficiency": "int64",
+            "interest_rate": "float64",
+            "type": "object",
+            "agent1": "int64",
+            "tech_type": "<U6",
+            "fixed_outputs": "float64",
+            "commodity_units": "object",
+            "fixed_inputs": "float64",
+            "flexible_inputs": "float64",
+            "comm_name": "object",
+            "emmission_factor": "float64",
+            "heat_rate": "int64",
+            "unit": "object",
+        },
+    )
+    assert DatasetSchema.from_ds(data) == expected_schema
+
+    # Check coordinate values
+    assert_coordinate_values(
+        data,
+        {
+            "commodity": ["electricity", "gas", "heat", "wind", "CO2f"],
+            "technology": ["gasCCGT", "windturbine"],
+            "region": ["R1"],
+            "year": [2020],
+            "comm_usage": [10, 9, 8, 6, 9],
+        },
+    )

--- a/tests/test_csv_readers.py
+++ b/tests/test_csv_readers.py
@@ -762,7 +762,6 @@ def test_read_technologies(model_path):
             "total_capacity_limit": "int64",
             "technical_life": "int64",
             "utilization_factor": "float64",
-            "scaling_size": "float64",
             "efficiency": "int64",
             "interest_rate": "float64",
             "type": "object",
@@ -789,5 +788,130 @@ def test_read_technologies(model_path):
             "region": ["R1"],
             "year": [2020],
             "comm_usage": [10, 9, 8, 6, 9],
+        },
+    )
+
+
+def test_read_technodata(model_path):
+    from muse.readers.toml import read_settings, read_technodata
+
+    settings = read_settings(model_path / "settings.toml")
+    data = read_technodata(
+        settings,
+        sector_name="power",
+        time_framework=settings.time_framework,
+        interpolation_mode="linear",
+    )
+
+    expected_schema = DatasetSchema(
+        dims={"year", "commodity", "technology", "region"},
+        coords={
+            "technology": CoordinateSchema(dims=("technology",), dtype="object"),
+            "region": CoordinateSchema(dims=("region",), dtype="object"),
+            "commodity": CoordinateSchema(dims=("commodity",), dtype="object"),
+            "comm_usage": CoordinateSchema(dims=("commodity",), dtype="object"),
+            "year": CoordinateSchema(dims=("year",), dtype="int64"),
+        },
+        data_vars={
+            "cap_par": "float64",
+            "cap_exp": "int64",
+            "fix_par": "int64",
+            "fix_exp": "int64",
+            "var_par": "int64",
+            "var_exp": "int64",
+            "max_capacity_addition": "int64",
+            "max_capacity_growth": "float64",
+            "total_capacity_limit": "int64",
+            "technical_life": "int64",
+            "utilization_factor": "float64",
+            "efficiency": "int64",
+            "interest_rate": "float64",
+            "type": "object",
+            "agent1": "int64",
+            "tech_type": "<U6",
+            "fixed_outputs": "float64",
+            "commodity_units": "object",
+            "fixed_inputs": "float64",
+            "flexible_inputs": "float64",
+            "comm_name": "object",
+            "emmission_factor": "float64",
+            "heat_rate": "int64",
+            "unit": "object",
+        },
+    )
+    assert DatasetSchema.from_ds(data) == expected_schema
+
+    # Check coordinate values
+    assert_coordinate_values(
+        data,
+        {
+            "commodity": ["electricity", "gas", "wind", "CO2f"],
+            "technology": ["gasCCGT", "windturbine"],
+            "region": ["R1"],
+            "year": [2020, 2025, 2030, 2035, 2040, 2045, 2050],
+            "comm_usage": [10, 9, 8, 6, 9],
+        },
+    )
+
+
+def test_read_technodata_trade(trade_model_path):
+    from muse.readers.toml import read_settings, read_technodata
+
+    settings = read_settings(trade_model_path / "settings.toml")
+    data = read_technodata(
+        settings,
+        sector_name="power",
+        time_framework=settings.time_framework,
+        interpolation_mode="linear",
+    )
+
+    expected_schema = DatasetSchema(
+        dims={"dst_region", "commodity", "year", "region", "technology"},
+        coords={
+            "technology": CoordinateSchema(dims=("technology",), dtype="object"),
+            "region": CoordinateSchema(dims=("region",), dtype="object"),
+            "commodity": CoordinateSchema(dims=("commodity",), dtype="object"),
+            "comm_usage": CoordinateSchema(dims=("commodity",), dtype="object"),
+            "dst_region": CoordinateSchema(dims=("dst_region",), dtype="object"),
+            "year": CoordinateSchema(dims=("year",), dtype="int64"),
+        },
+        data_vars={
+            "cap_exp": "int64",
+            "fix_exp": "int64",
+            "var_par": "int64",
+            "var_exp": "int64",
+            "technical_life": "int64",
+            "utilization_factor": "float64",
+            "efficiency": "int64",
+            "interest_rate": "float64",
+            "type": "object",
+            "agent1": "int64",
+            "tech_type": "<U6",
+            "fixed_outputs": "float64",
+            "commodity_units": "object",
+            "fixed_inputs": "float64",
+            "flexible_inputs": "float64",
+            "comm_name": "object",
+            "emmission_factor": "float64",
+            "heat_rate": "int64",
+            "unit": "object",
+            "max_capacity_addition": "float64",
+            "max_capacity_growth": "float64",
+            "total_capacity_limit": "float64",
+            "cap_par": "float64",
+            "fix_par": "float64",
+        },
+    )
+    assert DatasetSchema.from_ds(data) == expected_schema
+
+    # Check coordinate values
+    assert_coordinate_values(
+        data,
+        {
+            "commodity": ["electricity", "gas", "wind", "CO2f"],
+            "technology": ["gasCCGT", "windturbine"],
+            "region": ["R1", "R2"],
+            "dst_region": ["R1", "R2"],
+            "year": [2010, 2020, 2025, 2030, 2035],
         },
     )


### PR DESCRIPTION
# Description

Adding tests for a few more readers that weren't covered in #725 

We have `read_technologies` and `read_technodata`, which are mostly just wrappers over other reader functions, but there's enough processing going on that they deserve their own tests (particularly in the case of the trade model).

There's also some code in the presets factory which combines the presets data into a dataset. I've moved this into a new function and added a test for it, both for the default model and correlation model as these are a bit different

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
