### PR TITLE
Correctly pass timeslice level to capacity_to_service_demand

### DIFF
--- a/src/muse/objectives.py
+++ b/src/muse/objectives.py
@@ -227,13 +227,16 @@ def efficiency(
 def capacity_to_service_demand(
     technologies: xr.Dataset,
     demand: xr.DataArray,
+    timeslice_level: str | None = None,
     *args,
     **kwargs,
 ) -> xr.DataArray:
     """Minimum capacity required to fulfill the demand."""
     from muse.quantities import capacity_to_service_demand
 
-    return capacity_to_service_demand(demand=demand, technologies=technologies)
+    return capacity_to_service_demand(
+        demand=demand, technologies=technologies, timeslice_level=timeslice_level
+    )
 
 
 @register_objective
@@ -375,7 +378,9 @@ def fuel_consumption_cost(
     from muse.quantities import consumption
     from muse.timeslices import broadcast_timeslice, distribute_timeslice
 
-    capacity = capacity_to_service_demand(technologies, demand)
+    capacity = capacity_to_service_demand(
+        technologies, demand, timeslice_level=timeslice_level
+    )
     production = (
         broadcast_timeslice(capacity, level=timeslice_level)
         * distribute_timeslice(technologies.fixed_outputs, level=timeslice_level)


### PR DESCRIPTION
# Description

Tiny bug that was breaking the timeslice_level feature 

Unfortunately, since timeslice_level is an optional parameter for most functions (mostly to make the tests easier to write) it's easy to forget to pass it, but when this happens you can end up with timeslice-mismatch errors

Consider making timeslice_level mandatory to prevent this

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
