### PR TITLE
Fix some issues with flexible inputs

### DIFF
--- a/src/muse/readers/toml.py
+++ b/src/muse/readers/toml.py
@@ -593,13 +593,16 @@ def read_technodata(
 
     # Only keep commodities that are used as inputs or outputs
     dims = ("year", "region", "technology")
-    ins = (technologies.fixed_inputs > 0).any(
+    fixed_ins = (technologies.fixed_inputs > 0).any(
         [d for d in dims if d in technologies.fixed_inputs.dims]
+    )
+    flex_ins = (technologies.flexible_inputs > 0).any(
+        [d for d in dims if d in technologies.flexible_inputs.dims]
     )
     outs = (technologies.fixed_outputs > 0).any(
         [d for d in dims if d in technologies.fixed_outputs.dims]
     )
-    techcomms = technologies.commodity[ins | outs]
+    techcomms = technologies.commodity[fixed_ins | flex_ins | outs]
     technologies = technologies.sel(commodity=techcomms)
 
     # Read trade technodata

--- a/src/muse/sectors/sector.py
+++ b/src/muse/sectors/sector.py
@@ -280,6 +280,9 @@ class Sector(AbstractSector):  # type: ignore
             technologies, capacity, installed_as_year=True
         )
 
+        # Select relevant investment year prices for each asset
+        prices = broadcast_over_assets(market.prices.isel(year=1), capacity)
+
         # Calculate supply
         supply = self.supply_prod(
             market=market,
@@ -292,7 +295,7 @@ class Sector(AbstractSector):  # type: ignore
         consume = consumption(
             technologies=technodata,
             production=supply,
-            prices=market.prices,
+            prices=prices,
             timeslice_level=self.timeslice_level,
         )
 
@@ -305,7 +308,7 @@ class Sector(AbstractSector):  # type: ignore
             timeslice_level=self.timeslice_level,
         )
         lcoe = levelized_cost_of_energy(
-            prices=market.prices.sel(region=supply.region).isel(year=1),
+            prices=prices,
             technologies=technodata,
             capacity=utilized_capacity,
             production=supply.isel(year=1),


### PR DESCRIPTION
# Description

A couple of bug fixes to get flexible inputs working (my fault):
- we were throwing away flexible comm_in data at the input layer due to an error in `read_technodata`
- after fixing this, this revealed an error in `market_variables` where we were passing prices data in the wrong format to the `consumption` function (which is what chooses between flexible inputs based on their price). The correct approach is to select data for the investment year, then select data for each asset based on the region of the asset (which is handled by `broadcast_over_assets`)

Only popping up now as nobody has ever used flexible inputs until now

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass: `$ python -m pytest`
- [ ] The documentation builds and looks OK: `$ python -m sphinx -b html docs docs/build`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
