### PR TITLE
Simplifying the releases page

### DIFF
--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -5,34 +5,15 @@ This is the list of changes to MUSE between each release.
 
 To update to the latest version, run ``pip install --upgrade muse-os``
 
-
-.. list-table::
-   :widths: 50 50
-   :header-rows: 1
-
-   *  - Version
-      - Date
-   *  - :ref:`/release-notes/v1.4.3.md`
-      - 2025-06-25
-   *  - :ref:`/release-notes/v1.4.2.md`
-      - 2025-05-16
-   *  - :ref:`/release-notes/v1.4.1.md`
-      - 2025-05-9
-   *  - :ref:`/release-notes/v1.4.0.md`
-      - 2025-04-03
-   *  - :ref:`/release-notes/v1.3.3.md`
-      - 2025-02-07
-   *  - :ref:`/release-notes/v1.3.2.md`
-      - 2025-01-22
-   *  - :ref:`/release-notes/v1.3.1.md`
-      - 2024-12-19
-   *  - :ref:`/release-notes/v1.3.0.md`
-      - 2024-12-03
-   *  - :ref:`/release-notes/v1.2.3.md`
-      - 2024-11-19
-   *  - :ref:`/release-notes/v1.2.2.md`
-      - 2024-08-28
-   *  - :ref:`/release-notes/v1.2.1.md`
-      - 2024-08-09
-   *  - :ref:`/release-notes/v1.2.0.md`
-      - 2024-07-19
+* :ref:`/release-notes/v1.4.3.md`
+* :ref:`/release-notes/v1.4.2.md`
+* :ref:`/release-notes/v1.4.1.md`
+* :ref:`/release-notes/v1.4.0.md`
+* :ref:`/release-notes/v1.3.3.md`
+* :ref:`/release-notes/v1.3.2.md`
+* :ref:`/release-notes/v1.3.1.md`
+* :ref:`/release-notes/v1.3.0.md`
+* :ref:`/release-notes/v1.2.3.md`
+* :ref:`/release-notes/v1.2.2.md`
+* :ref:`/release-notes/v1.2.1.md`
+* :ref:`/release-notes/v1.2.0.md`


### PR DESCRIPTION
No need to list all the releases in the main menu, just have a list on the release page instead