### PR TITLE
Improved error handling for existing_capacity file

### DIFF
--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 __all__ = [
     "read_agent_parameters",
     "read_attribute_table",
+    "read_csv",
     "read_existing_trade",
     "read_global_commodities",
     "read_initial_capacity",
@@ -276,6 +277,9 @@ def standardize_dataframe(
     Returns:
         DataFrame containing the standardized data
     """
+    if required_columns is None:
+        required_columns = []
+
     # Standardize column names
     data = standardize_columns(data)
 
@@ -294,7 +298,7 @@ def standardize_dataframe(
     data = convert_column_types(data)
 
     # Validate required columns if provided
-    if required_columns is not None:
+    if required_columns:
         missing_columns = [col for col in required_columns if col not in data.columns]
         if missing_columns:
             raise ValueError(f"Missing required columns: {missing_columns}")

--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -118,14 +118,16 @@ class Subsector:
         from muse import investments as iv
         from muse.agents import InvestingAgent, agents_factory
         from muse.commodities import is_enduse
-        from muse.readers import read_existing_trade, read_initial_capacity
+        from muse.readers import read_csv, read_existing_trade, read_initial_capacity
 
         # Read existing capacity or existing trade file
-        try:
+        # Have to peek at the file to determine what format the data is in
+        # TODO: ideally would be more explicit about this. Consider changing
+        # the parameter name in the settings file
+        df = read_csv(settings.existing_capacity)
+        if "year" not in df.columns:
             existing_capacity = read_initial_capacity(settings.existing_capacity)
-        except ValueError:
-            # TODO: ideally would be more explicit about this. Consider changing
-            # the parameter name in the settings file
+        else:
             existing_capacity = read_existing_trade(settings.existing_capacity)
 
         # Create agents


### PR DESCRIPTION
It was giving a confusing error message when there were any problems with the existing capacity file as it was then trying to read it as a trade file. Using a more explicit approach to prevent this