### PR TITLE
Convert timeslice levels to snake_case

### DIFF
--- a/src/muse/readers/csv.py
+++ b/src/muse/readers/csv.py
@@ -54,6 +54,8 @@ from pathlib import Path
 import pandas as pd
 import xarray as xr
 
+from muse.utilities import camel_to_snake
+
 # Global mapping of column names to their standardized versions
 # This is for backwards compatibility with old file formats
 COLUMN_RENAMES = {
@@ -74,6 +76,8 @@ COLUMN_RENAMES = {
     "objsort1": "obj_sort1",
     "objsort2": "obj_sort2",
     "objsort3": "obj_sort3",
+    "time_slice": "timeslice",
+    "price": "prices",
 }
 
 # Columns who's values should be converted from camelCase to snake_case
@@ -224,19 +228,6 @@ def get_nan_coordinates(dataset: xr.Dataset) -> list[tuple]:
     if any_nan.any():
         return any_nan.where(any_nan, drop=True).to_dataframe(name="").index.to_list()
     return []
-
-
-def camel_to_snake(name: str) -> str:
-    """Transforms CamelCase to snake_case."""
-    from re import sub
-
-    pattern = sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
-    result = sub("([a-z0-9])([A-Z])", r"\1_\2", pattern).lower()
-    result = result.replace("co2", "CO2")
-    result = result.replace("ch4", "CH4")
-    result = result.replace("n2_o", "N2O")
-    result = result.replace("f-gases", "F-gases")
-    return result
 
 
 def convert_column_types(data: pd.DataFrame) -> pd.DataFrame:

--- a/src/muse/readers/toml.py
+++ b/src/muse/readers/toml.py
@@ -374,12 +374,18 @@ def setup_time_framework(settings: dict) -> None:
 @register_settings_hook(priority=1)
 def standardise_case(settings: dict) -> None:
     """Standardise certain fields to snake_case."""
-    from muse.readers.csv import camel_to_snake
+    from muse.utilities import camel_to_snake
 
     fields_to_standardise = ["excluded_commodities", "regions"]
     for field in fields_to_standardise:
         if field in settings:
             settings[field] = [camel_to_snake(x) for x in settings[field]]
+
+    # Handle timeslice level_names if present
+    if "level_names" in settings["timeslices"]:
+        settings["timeslices"]["level_names"] = [
+            camel_to_snake(x) for x in settings["timeslices"]["level_names"]
+        ]
 
 
 @register_settings_hook

--- a/src/muse/utilities.py
+++ b/src/muse/utilities.py
@@ -675,3 +675,16 @@ def interpolate_technodata(
     years = sorted(set(time_framework).union(data.year.values.tolist()))
     data = data.interp(year=years, method=interpolation_mode)
     return data
+
+
+def camel_to_snake(name: str) -> str:
+    """Transforms CamelCase to snake_case."""
+    from re import sub
+
+    pattern = sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    result = sub("([a-z0-9])([A-Z])", r"\1_\2", pattern).lower()
+    result = result.replace("co2", "CO2")
+    result = result.replace("ch4", "CH4")
+    result = result.replace("n2_o", "N2O")
+    result = result.replace("f-gases", "F-gases")
+    return result


### PR DESCRIPTION
Since csv files all use snake_case for column names, there could be a mismatch if the level names in the toml file are not also converted to snake_case