### PR TITLE
Don't apply the `with_asset_technology` filter by default

### DIFF
--- a/src/muse/agents/factories.py
+++ b/src/muse/agents/factories.py
@@ -71,14 +71,10 @@ def create_retrofit_agent(
 
     kwargs = _standardize_investing_inputs(decision=decision, **kwargs)
 
-    search_rules = kwargs.pop("search_rules")
-    if len(search_rules) < 2 or search_rules[-2] != "with_asset_technology":
-        search_rules.insert(-1, "with_asset_technology")
-
     return InvestingAgent(
         assets=xr.Dataset(dict(capacity=assets)),
         region=region,
-        search_rules=filter_factory(search_rules),
+        search_rules=filter_factory(kwargs.pop("search_rules")),
         year=year,
         **kwargs,
     )
@@ -139,9 +135,6 @@ def create_newcapa_agent(
         "currently_referenced_tech" if name in variations else name
         for name in kwargs.pop("search_rules")
     ]
-
-    if not retrofit_present and "with_asset_technology" not in search_rules:
-        search_rules.insert(-1, "with_asset_technology")
 
     result = InvestingAgent(
         assets=assets,


### PR DESCRIPTION
# Description

There was an observation from Martin/Sharwari of agents investing in technologies that should be excluded by the agent's search rule (in this case it was investing in technologies with a capital cost higher than the agent's spend limit).

I believe this is caused by `with_asset_technology` filter, which allows agents to consider all existing(/just decomissioned) asset technologies for further investment, even if those technologies don't meet the criteria of the other agent filters.

```
@register_filter
def with_asset_technology(
    agent: Agent,
    search_space: xr.DataArray,
    **kwargs,
) -> xr.DataArray:
    """Search space *also* contains its asset technology for each asset."""
    return search_space | (search_space.asset == search_space.replacement)
```

This is applied by default _even if the user doesn't specify this in the input files_. This seems a bit nonsense to me, even for retrofit agents. If a technology doesn't meet the criteria of the agent filters, I don't think we should consider it even if it's in the current asset pool (maybe it was viable at the time of investment, but parameters can change over time so it might not be viable any more).

I've decided to remove the logic in the agents factory that automatically applies this filter, but keep the filter present as an option in `filters.py` (so users can still include it by chaining filters e.g. "spend_limit->with_asset_technology")