### PR TITLE
Fix bug with LCOE/EAC outputs

### DIFF
--- a/src/muse/outputs/mca.py
+++ b/src/muse/outputs/mca.py
@@ -376,7 +376,7 @@ def sector_lcoe(
     agents = retro if len(retro) > 0 else new
     if len(technologies) > 0:
         for agent in agents:
-            agent_market = market.sel(year=agent.year)
+            agent_market = market.sel(year=agent.year).copy(deep=True)
             agent_market["consumption"] = agent_market.consumption * agent.quantity
 
             # Filter commodities based on end-use status
@@ -465,7 +465,7 @@ def sector_eac(
     agents = retro if len(retro) > 0 else new
     if len(technologies) > 0:
         for agent in agents:
-            agent_market = market.sel(year=agent.year)
+            agent_market = market.sel(year=agent.year).copy(deep=True)
             agent_market["consumption"] = agent_market.consumption * agent.quantity
 
             # Filter commodities based on end-use status


### PR DESCRIPTION
# Description

This was an extremely annoying (and worrying) bug that took me the best part of a day to figure out

It started with an observation that some of the values in the LCOE output file were zero, even though the actual LCOE should definitely __not__ be zero. I then realised this was because some of the prices used in the LCOE calculation were zero, even though the prices passed to `sector_lcoe` in the `market` object weren't zero. The reason is that `market` gets modified within `sector_lcoe` before the prices are extracted and used in the LCOE calculation. However, you wouldn't know this by looking at the code. It's due to a subtle behaviour of xarray's `sel` function. I (and presumably other people developing MUSE) have assumed that `sel` creates a copy of the underlying data, but this is NOT TRUE

From the xarray documentation:
"In general, each array’s data will be a view of the array’s data in this DataArray, unless vectorized indexing was triggered by using an array indexer, in which case the data will be a copy."

This is relevant here because the line `agent_market = market.sel(year=agent.year)` returns a __view__ of the data in `market` rather than a copy. Therefore, when `agent_market` is modified later (`agent_market.loc[dict(commodity=excluded_commodities)] = 0`), this actually modifies the data in `market`. Then, when we later extract the price values from `market` (`agent_market["prices"] = agent.filter_input(market["prices"], year=agent.year)`), we get these modified values (with certain prices set to zero), not the original values.

Now that I know the problem, this is easy to fix by forcing a deep copy with `.copy(deep=True)`. However, I'm pretty spooked by this and it's difficult to know that there aren't other similar mistakes like this throughout the code (a search for ".sel(" gives 260 results, and I'd be very surprised if none of these made similar mistakes).

This is exactly the kind of reason that Rust is superior and MUSE1 can't die soon enough

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deep-copies per-agent `market` slice in LCOE and EAC calculations to avoid mutating the original dataset during filtering and price assignment.
> 
> - **Outputs (MCA)**:
>   - **LCOE/EAC calculations**:
>     - Use `market.sel(year=agent.year).copy(deep=True)` when creating `agent_market` in `sector_lcoe` and `sector_eac` to prevent unintended mutation of `market` during commodity filtering and price updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4585da1f26720615228315e92fe5a76c3ffaeb93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->