### PR TITLE
Remove data processing in cache function

### DIFF
--- a/src/muse/outputs/cache.py
+++ b/src/muse/outputs/cache.py
@@ -409,9 +409,12 @@ def consolidate_quantity(
     """
     data = _aggregate_cache(quantity, cached)
 
+    ignore_dst_region = "dst_region" in data.columns
     for agent in tuple(agents):
         filter = data.agent == agent
         for key, value in agents[agent].items():
+            if key == "dst_region" and ignore_dst_region:
+                continue
             data.loc[filter, key] = value
 
     return data[sorted(data.columns)]

--- a/src/muse/outputs/cache.py
+++ b/src/muse/outputs/cache.py
@@ -409,26 +409,11 @@ def consolidate_quantity(
     """
     data = _aggregate_cache(quantity, cached)
 
-    ignore_dst_region = "dst_region" in data.columns
     for agent in tuple(agents):
         filter = data.agent == agent
         for key, value in agents[agent].items():
-            if key == "dst_region" and ignore_dst_region:
-                continue
             data.loc[filter, key] = value
 
-    data = data.rename(columns={"replacement": "technology"})
-
-    group_cols = [c for c in data.columns if c not in [quantity, "asset"]]
-    data = (
-        data.groupby(group_cols)
-        .sum()
-        .infer_objects()
-        .fillna(0)
-        .reset_index()
-        .drop("asset", axis=1, errors="ignore")
-    )
-    data = data[data[quantity] != 0]
     return data[sorted(data.columns)]
 
 

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -577,8 +577,16 @@ def test_consolidate_quantity(newcapa_agent, retro_agent):
     b = create_agent_array(retro_agent.uuid, modify_first=True)
 
     actual = consolidate_quantity("height", [a, b], agents)
-    cols = set((*agents[retro_agent.uuid].keys(), "technology", "height"))
-    assert set(actual.columns) == cols
+    assert set(actual.columns) == {
+        "agent",
+        "asset",
+        "category",
+        "sector",
+        "dst_region",
+        "height",
+        "replacement",
+        "sector",
+    }
     assert all(
         name in (newcapa_agent.name, retro_agent.name) for name in actual.agent.unique()
     )


### PR DESCRIPTION
# Description

The cache should give a raw view of the data (this is mostly for developers, ie me, rather than end users), so we shouldn't perform operations like grouping, summing and renaming columns. If someone want to do this later on then fine, but we shouldn't do this within MUSE as it loses data and may do something stupid (like summing LCOEs) 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops grouping/summing/renaming and special dst_region handling in cache consolidation; updates tests to expect raw columns (e.g., replacement, asset).
> 
> - **Outputs Cache**:
>   - Remove post-processing in `consolidate_quantity`:
>     - Drop `dst_region` ignore logic, column rename (`replacement`->`technology`), groupby/sum, zero filtering, and `asset` drop.
>   - Now returns raw merged DataFrame with original columns.
> - **Tests**:
>   - Update `test_consolidate_quantity` expected columns to include raw fields (e.g., `replacement`, `asset`) and remove expectation of `technology`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7876e118f4704f0b85f277db133b7b63d48c2fda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->