### PR TITLE
Filter demands to prevent 0/0 division error

### DIFF
--- a/src/muse/sectors/subsector.py
+++ b/src/muse/sectors/subsector.py
@@ -87,6 +87,11 @@ class Subsector:
             timeslice_level=self.timeslice_level,
         )
 
+        # Further filer demands to only include commodities with positive unmet demand
+        # Some commodities may be lost here if capacity is already sufficient to meet
+        # demand
+        demands = demands.where(demands.sum(["timeslice", "asset"]) > 0, drop=True)
+
         if "dst_region" in demands.dims:
             msg = """
                 dst_region found in demand dimensions. This is unexpected. Demands


### PR DESCRIPTION
We already filter demands to remove zeros to prevent 0/0 division errors (particularly in the demand limiting capacity constraint). But there was one scenario we weren't considering: the case where _capacity is already sufficient to meet demand_. In this case, demands passed to `aggregate_lp` are positive, but demands from `self.demand_share` (which takes existing capacity into account to calculate _unmet_ demand) may be zero. We therefore need to filter this again before passing to `agent.next` 