### PR TITLE
Pin pandas to <3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "numpy>=2.0",
     "scipy>=1.13",
-    "pandas>=2.2",
+    "pandas>=2.2,<3.0",
     "xarray>=2024.6,<=2024.11",
     "bottleneck>=1.4",
     "coloredlogs",


### PR DESCRIPTION
Annoyingly a few things break when using pandas 3.0

Until I can fix this I'm pinning pandas to <3.0

Unfortunately it's very possible that any fixes also break compatibility with pandas v2, so we may also have to drop support for python versions that don't work with pandas v3 (i.e. 3.9 and 3.10). Probably not such a bad idea though as python 3.9 is already end of life and 3.10 is soon to be