### PR TITLE
Exclude un-produced commodities from sector "costs" output

### DIFF
--- a/src/muse/outputs/sector.py
+++ b/src/muse/outputs/sector.py
@@ -183,7 +183,7 @@ def consumption(
     sum_over: list[str] | None = None,
     drop: list[str] | None = None,
     **kwargs,
-) -> xr.DataArray:
+) -> pd.DataFrame:
     """Current consumption."""
     moutput = market.copy(deep=True).reset_index("timeslice")
     result = (
@@ -202,7 +202,7 @@ def supply(
     sum_over: list[str] | None = None,
     drop: list[str] | None = None,
     **kwargs,
-) -> xr.DataArray:
+) -> pd.DataFrame:
     """Current supply."""
     moutput = market.copy(deep=True).reset_index("timeslice")
     result = (
@@ -223,10 +223,10 @@ def costs(
     *,
     commodities: list[str],
     **kwargs,
-) -> xr.DataArray:
+) -> pd.DataFrame:
     """Weighted average cost of production (filtered where total supply > 0)."""
     costs = market_quantity(market.costs, sum_over=sum_over, drop=drop)
-    supply = market_quantity(market.supply, sum_over="asset", drop=drop)
+    supply = market_quantity(market.supply.sum("asset"), sum_over, drop=drop)
 
     # Mask costs where supply is effectively zero
     costs = costs.where(supply > 1e-15)

--- a/src/muse/outputs/sector.py
+++ b/src/muse/outputs/sector.py
@@ -220,11 +220,17 @@ def costs(
     drop: list[str] | None = None,
     **kwargs,
 ) -> xr.DataArray:
-    """Current costs."""
+    """Cost of production (filtered where supply > 0)."""
+    costs_da = market_quantity(market.costs, sum_over=sum_over, drop=drop)
+    supply_da = market_quantity(market.supply, sum_over=sum_over, drop=drop)
+
+    # Mask costs where supply is zero
+    costs_filtered = costs_da.where(supply_da > 1e-15)
+
     result = (
-        market_quantity(market.costs, sum_over=sum_over, drop=drop)
-        .rename("costs")
+        costs_filtered.rename("costs")
         .to_dataframe()
         .reset_index()
+        .dropna(subset=["costs"])  # drop NaN rows (i.e., where supply was zero)
     )
     return result

--- a/src/muse/outputs/sector.py
+++ b/src/muse/outputs/sector.py
@@ -162,7 +162,7 @@ def market_quantity(
     if isinstance(sum_over, str):
         sum_over = [sum_over]
     if sum_over:
-        sum_over = [s for s in sum_over if s in quantity.coords]
+        sum_over = [s for s in sum_over if s in quantity.dims]
     if sum_over:
         quantity = quantity.sum(sum_over)
     if "timeslice" in quantity.coords and isinstance(
@@ -220,9 +220,9 @@ def costs(
     drop: list[str] | None = None,
     **kwargs,
 ) -> xr.DataArray:
-    """Cost of production (filtered where supply > 0)."""
+    """Weighted average cost of production (filtered where total supply > 0)."""
     costs_da = market_quantity(market.costs, sum_over=sum_over, drop=drop)
-    supply_da = market_quantity(market.supply, sum_over=sum_over, drop=drop)
+    supply_da = market_quantity(market.supply, sum_over="asset", drop=drop)
 
     # Mask costs where supply is zero
     costs_filtered = costs_da.where(supply_da > 1e-15)

--- a/src/muse/outputs/sector.py
+++ b/src/muse/outputs/sector.py
@@ -102,12 +102,14 @@ def _factory(
     quantities = [_quantity_factory(param, registry) for param in params]
     sinks = [sink_factory(param, sector_name=sector_name) for param in params]
 
-    def save_multiple_outputs(market, *args, year: int | None = None) -> list[Any]:
+    def save_multiple_outputs(
+        market, *args, year: int | None = None, **kwargs
+    ) -> list[Any]:
         if year is None:
             year = int(market.year.max())
 
         return [
-            sink(quantity(market, *args, year=year), year=year)
+            sink(quantity(market, *args, year=year, **kwargs), year=year)
             for quantity, sink in zip(quantities, sinks)
         ]
 
@@ -218,19 +220,22 @@ def costs(
     capacity: xr.DataArray,
     sum_over: list[str] | None = None,
     drop: list[str] | None = None,
+    *,
+    commodities: list[str],
     **kwargs,
 ) -> xr.DataArray:
     """Weighted average cost of production (filtered where total supply > 0)."""
-    costs_da = market_quantity(market.costs, sum_over=sum_over, drop=drop)
-    supply_da = market_quantity(market.supply, sum_over="asset", drop=drop)
+    costs = market_quantity(market.costs, sum_over=sum_over, drop=drop)
+    supply = market_quantity(market.supply, sum_over="asset", drop=drop)
 
-    # Mask costs where supply is zero
-    costs_filtered = costs_da.where(supply_da > 1e-15)
+    # Mask costs where supply is effectively zero
+    costs = costs.where(supply > 1e-15)
 
-    result = (
-        costs_filtered.rename("costs")
-        .to_dataframe()
-        .reset_index()
-        .dropna(subset=["costs"])  # drop NaN rows (i.e., where supply was zero)
-    )
+    # Filter to only include commodities owned by the sector (i.e. excludes
+    # environmental commodities)
+    costs = costs.sel(commodity=costs.commodity.isin(commodities))
+
+    # Create a DataFrame from the filtered costs, dropping rows where costs are NaN
+    # (i.e., where supply was zero)
+    result = costs.rename("costs").to_dataframe().reset_index().dropna(subset=["costs"])
     return result

--- a/src/muse/sectors/sector.py
+++ b/src/muse/sectors/sector.py
@@ -267,7 +267,9 @@ class Sector(AbstractSector):  # type: ignore
 
     def save_outputs(self, year: int) -> None:
         """Calls the outputs function with the current output data."""
-        self.outputs(self.output_data, self.capacity, year=year)
+        self.outputs(
+            self.output_data, self.capacity, year=year, commodities=self.commodities
+        )
 
     def market_variables(self, market: xr.Dataset, technologies: xr.Dataset) -> Any:
         """Computes resulting market: production, consumption, and costs."""


### PR DESCRIPTION
This filters the sector "costs" output file (which gives the weighted average cost of production of commodities) to only include commodities that are actually produced. Commodities with supply of zero were previously included as rows with zero costs (just due to a slight quirk in the way that supply costs are calculated, see [this function](https://github.com/EnergySystemsModellingLab/MUSE_OS/blob/62a681f29713e1317f2d570dd96b0655d6658bde/src/muse/costs.py#L525)). Now these rows will no longer appear.

I also decided to filter this further to only include commodities "owned" by the sector (i.e. commodities that the sector is trying to meet the demands of). This effectively excludes environmental commodities such as CO2, which may be produced and have a "supply cost", but is pretty meaningless and potentially confusing so probably better to exclude.

Also fixing a bug in `market_quantity` related to the `sum_over` argument which was previously unused